### PR TITLE
Refactor/ref

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -69,8 +69,6 @@ There are two different kind of [Defs](@ref mim::Def) in MimIR: _mutables_ and _
 ## Matching IR
 
 MimIR provides different means to scrutinize [Defs](@ref mim::Def).
-Usually, you will encounter a [Def](@ref mim::Def) as [Ref](@ref mim::Ref) which is just a wrapper for a `const Def*`.
-Its purpose is to resolve "holes" (called _[Infer](@ref mim::Infer)s_ in MimIR) that may pop up due to type inference.
 Matching built-ins, i.e. all subclasses of [Def](@ref mim::Def), works differently than matching [Axiom](@ref mim::Axiom)s.
 
 ### Upcast for Built-ins {#cast_builtin}

--- a/gtest/test.cpp
+++ b/gtest/test.cpp
@@ -103,7 +103,7 @@ TEST(trait, idx) {
     EXPECT_EQ(Lit::as(op(core::trait::size, w.type_idx(0x0000'0000'0000'0000_n))), 8);
 }
 
-Ref normalize_test_curry(Ref type, Ref callee, Ref arg) {
+const Def* normalize_test_curry(const Def* type, const Def* callee, const Def* arg) {
     auto& w = arg->world();
     return w.raw_app(type, callee, w.lit_nat(42));
 }
@@ -214,7 +214,7 @@ TEST(Check, alpha) {
     // λ_.1
     auto l_1 = w.lam(pi, false, w.lit_nat_1());
 
-    auto check = [](Ref l1, Ref l2, bool infer_res, bool non_infer_res) {
+    auto check = [](const Def* l1, const Def* l2, bool infer_res, bool non_infer_res) {
         EXPECT_EQ(Checker::alpha<Checker::Check>(l1, l2), infer_res);
         EXPECT_EQ(Checker::alpha<Checker::Check>(l2, l1), infer_res);
         EXPECT_EQ(Checker::alpha<Checker::Test>(l1, l2), non_infer_res);

--- a/include/mim/ast/ast.h
+++ b/include/mim/ast/ast.h
@@ -149,13 +149,13 @@ public:
     static constexpr bool is_rassoc(Prec p) { return p == Prec::Arrow; }
     ///@}
 
-    Ref emit(Emitter&) const;
+    const Def* emit(Emitter&) const;
     virtual void bind(Scopes&) const = 0;
-    virtual Ref emit_decl(Emitter&, Ref /*type*/) const { fe::unreachable(); }
-    virtual void emit_body(Emitter&, Ref /*decl*/) const { fe::unreachable(); }
+    virtual const Def* emit_decl(Emitter&, const Def* /*type*/) const { fe::unreachable(); }
+    virtual void emit_body(Emitter&, const Def* /*decl*/) const { fe::unreachable(); }
 
 private:
-    virtual Ref emit_(Emitter&) const = 0;
+    virtual const Def* emit_(Emitter&) const = 0;
 };
 
 class Decl : public Node {
@@ -164,10 +164,10 @@ protected:
         : Node(loc) {}
 
 public:
-    Ref def() const { return def_; }
+    const Def* def() const { return def_; }
 
 protected:
-    mutable Ref def_ = nullptr;
+    mutable const Def* def_ = nullptr;
 };
 
 class ValDecl : public Decl {
@@ -192,8 +192,8 @@ public:
     virtual bool is_implicit() const { return false; }
 
     virtual void bind(Scopes&, bool rebind, bool quiet) const = 0;
-    virtual Ref emit_value(Emitter&, Ref) const               = 0;
-    virtual Ref emit_type(Emitter&) const                     = 0;
+    virtual const Def* emit_value(Emitter&, const Def*) const = 0;
+    virtual const Def* emit_type(Emitter&) const              = 0;
 
     [[nodiscard]] static Ptr<Expr> to_expr(AST&, Ptr<Ptrn>&&);
     [[nodiscard]] static Ptr<Ptrn> to_ptrn(Ptr<Expr>&&);
@@ -205,8 +205,8 @@ public:
         : Ptrn(loc) {}
 
     void bind(Scopes&, bool rebind, bool quiet) const override;
-    Ref emit_value(Emitter&, Ref) const override;
-    Ref emit_type(Emitter&) const override;
+    const Def* emit_value(Emitter&, const Def*) const override;
+    const Def* emit_type(Emitter&) const override;
     std::ostream& stream(Tab&, std::ostream&) const override;
 };
 
@@ -231,8 +231,8 @@ public:
     }
 
     void bind(Scopes&, bool rebind, bool quiet) const override;
-    Ref emit_value(Emitter&, Ref) const override;
-    Ref emit_type(Emitter&) const override;
+    const Def* emit_value(Emitter&, const Def*) const override;
+    const Def* emit_type(Emitter&) const override;
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
@@ -252,8 +252,8 @@ public:
     const IdPtrn* id() const { return id_; }
 
     void bind(Scopes&, bool rebind, bool quiet) const override;
-    Ref emit_value(Emitter&, Ref) const override;
-    Ref emit_type(Emitter&) const override;
+    const Def* emit_value(Emitter&, const Def*) const override;
+    const Def* emit_type(Emitter&) const override;
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
@@ -274,8 +274,8 @@ public:
     bool is_implicit() const override { return ptrn()->is_implicit(); }
 
     void bind(Scopes&, bool rebind, bool quiet) const override;
-    Ref emit_value(Emitter&, Ref) const override;
-    Ref emit_type(Emitter&) const override;
+    const Def* emit_value(Emitter&, const Def*) const override;
+    const Def* emit_type(Emitter&) const override;
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
@@ -302,10 +302,10 @@ public:
     size_t num_ptrns() const { return ptrns().size(); }
 
     void bind(Scopes&, bool rebind, bool quiet) const override;
-    Ref emit_value(Emitter&, Ref) const override;
-    Ref emit_type(Emitter&) const override;
-    Ref emit_decl(Emitter&, Ref type) const;
-    Ref emit_body(Emitter&, Ref decl) const;
+    const Def* emit_value(Emitter&, const Def*) const override;
+    const Def* emit_type(Emitter&) const override;
+    const Def* emit_decl(Emitter&, const Def* type) const;
+    const Def* emit_body(Emitter&, const Def* decl) const;
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
@@ -326,7 +326,7 @@ public:
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
-    Ref emit_(Emitter&) const override;
+    const Def* emit_(Emitter&) const override;
 };
 
 class InferExpr : public Expr {
@@ -338,7 +338,7 @@ public:
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
-    Ref emit_(Emitter&) const override;
+    const Def* emit_(Emitter&) const override;
 };
 
 /// `sym`
@@ -355,7 +355,7 @@ public:
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
-    Ref emit_(Emitter&) const override;
+    const Def* emit_(Emitter&) const override;
 
     Dbg dbg_;
     mutable const Decl* decl_ = nullptr;
@@ -376,7 +376,7 @@ public:
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
-    Ref emit_(Emitter&) const override;
+    const Def* emit_(Emitter&) const override;
 
     Tok::Tag tag_;
 };
@@ -397,7 +397,7 @@ public:
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
-    Ref emit_(Emitter&) const override;
+    const Def* emit_(Emitter&) const override;
 
     Tok tok_;
     Ptr<Expr> type_;
@@ -420,7 +420,7 @@ public:
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
-    Ref emit_(Emitter&) const override;
+    const Def* emit_(Emitter&) const override;
 
     Ptrs<ValDecl> decls_;
     Ptr<Expr> expr_;
@@ -440,7 +440,7 @@ public:
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
-    Ref emit_(Emitter&) const override;
+    const Def* emit_(Emitter&) const override;
 
     Ptr<Expr> level_;
 };
@@ -460,12 +460,12 @@ private:
     const Expr* codom() const { return codom_.get(); }
 
     void bind(Scopes&) const override;
-    Ref emit_decl(Emitter&, Ref type) const override;
-    void emit_body(Emitter&, Ref decl) const override;
+    const Def* emit_decl(Emitter&, const Def* type) const override;
+    void emit_body(Emitter&, const Def* decl) const override;
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
-    Ref emit_(Emitter&) const override;
+    const Def* emit_(Emitter&) const override;
 
     Ptr<Expr> dom_;
     Ptr<Expr> codom_;
@@ -498,7 +498,7 @@ public:
         std::ostream& stream(Tab&, std::ostream&) const override;
 
     protected:
-        const Pi* set_codom(Ref codom) const {
+        const Pi* set_codom(const Def* codom) const {
             if (auto imm = pi_->set_codom(codom)->immutabilize()) return const_pi_ = imm;
             return const_pi_ = pi_;
         }
@@ -526,12 +526,12 @@ private:
     const Expr* codom() const { return codom_.get(); }
 
     void bind(Scopes&) const override;
-    Ref emit_decl(Emitter&, Ref type) const override;
-    void emit_body(Emitter&, Ref decl) const override;
+    const Def* emit_decl(Emitter&, const Def* type) const override;
+    void emit_body(Emitter&, const Def* decl) const override;
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
-    Ref emit_(Emitter&) const override;
+    const Def* emit_(Emitter&) const override;
 
     Tok::Tag tag_;
     Ptr<Dom> dom_;
@@ -546,12 +546,12 @@ public:
     const LamDecl* lam() const { return lam_.get(); }
 
     void bind(Scopes&) const override;
-    Ref emit_decl(Emitter&, Ref type) const override;
-    void emit_body(Emitter&, Ref decl) const override;
+    const Def* emit_decl(Emitter&, const Def* type) const override;
+    void emit_body(Emitter&, const Def* decl) const override;
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
-    Ref emit_(Emitter&) const override;
+    const Def* emit_(Emitter&) const override;
 
     Ptr<LamDecl> lam_;
 };
@@ -573,7 +573,7 @@ public:
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
-    Ref emit_(Emitter&) const override;
+    const Def* emit_(Emitter&) const override;
 
     bool is_explicit_;
     Ptr<Expr> callee_;
@@ -599,7 +599,7 @@ public:
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
-    Ref emit_(Emitter&) const override;
+    const Def* emit_(Emitter&) const override;
 
     Ptr<Ptrn> ptrn_;
     Ptr<Expr> callee_;
@@ -618,12 +618,12 @@ public:
     const TuplePtrn* ptrn() const { return ptrn_.get(); }
 
     void bind(Scopes&) const override;
-    Ref emit_decl(Emitter&, Ref type) const override;
-    void emit_body(Emitter&, Ref decl) const override;
+    const Def* emit_decl(Emitter&, const Def* type) const override;
+    void emit_body(Emitter&, const Def* decl) const override;
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
-    Ref emit_(Emitter&) const override;
+    const Def* emit_(Emitter&) const override;
 
     Ptr<TuplePtrn> ptrn_;
 
@@ -645,7 +645,7 @@ public:
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
-    Ref emit_(Emitter&) const override;
+    const Def* emit_(Emitter&) const override;
 
     Ptrs<Expr> elems_;
 };
@@ -665,7 +665,7 @@ public:
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
-    Ref emit_(Emitter&) const override;
+    const Def* emit_(Emitter&) const override;
 
     Ptr<IdPtrn> shape_;
     Ptr<Expr> body_;
@@ -694,7 +694,7 @@ public:
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
-    Ref emit_(Emitter&) const override;
+    const Def* emit_(Emitter&) const override;
 
     Ptr<Expr> tuple_;
     std::variant<Ptr<Expr>, Dbg> index_;
@@ -718,7 +718,7 @@ public:
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
-    Ref emit_(Emitter&) const override;
+    const Def* emit_(Emitter&) const override;
 
     Ptr<Expr> tuple_;
     Ptr<Expr> index_;
@@ -738,7 +738,7 @@ public:
     std::ostream& stream(Tab&, std::ostream&) const override;
 
 private:
-    Ref emit_(Emitter&) const override;
+    const Def* emit_(Emitter&) const override;
 
     Ptr<Expr> inhabitant_;
 };
@@ -819,7 +819,7 @@ private:
     Dbg normalizer_;
     Tok curry_, trip_;
     mutable AnnexInfo* annex_ = nullptr;
-    mutable Ref mim_type_;
+    mutable const Def* mim_type_;
 };
 
 /// `.rec dbg: type = body`

--- a/include/mim/axiom.h
+++ b/include/mim/axiom.h
@@ -63,7 +63,7 @@ public:
     static constexpr auto Node = Node::Axiom;
 
 private:
-    Ref rebuild_(World&, Ref, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const override;
 
     friend class World;
 };
@@ -109,7 +109,7 @@ private:
 /// @name match/force
 ///@{
 /// @see @ref cast_axiom
-template<class Id, bool DynCast = true> auto match(Ref def) {
+template<class Id, bool DynCast = true> auto match(const Def* def) {
     using D                = typename Axiom::Match<Id>::type;
     auto [axiom, curry, _] = Axiom::get(def);
     bool cond              = axiom && curry == 0 && axiom->base() == Annex::Base<Id>;
@@ -119,7 +119,7 @@ template<class Id, bool DynCast = true> auto match(Ref def) {
     return Match<Id, D>(axiom, def->as<D>());
 }
 
-template<class Id, bool DynCast = true> auto match(Id id, Ref def) {
+template<class Id, bool DynCast = true> auto match(Id id, const Def* def) {
     using D                = typename Axiom::Match<Id>::type;
     auto [axiom, curry, _] = Axiom::get(def);
     bool cond              = axiom && curry == 0 && axiom->flags() == (flags_t)id;
@@ -130,8 +130,8 @@ template<class Id, bool DynCast = true> auto match(Id id, Ref def) {
 }
 
 // clang-format off
-template<class Id> auto force(       Ref def) { return match<Id, false>(    def); }
-template<class Id> auto force(Id id, Ref def) { return match<Id, false>(id, def); }
+template<class Id> auto force(       const Def* def) { return match<Id, false>(    def); }
+template<class Id> auto force(Id id, const Def* def) { return match<Id, false>(id, def); }
 ///@}
 
 /// @name is_commutative/is_associative

--- a/include/mim/check.h
+++ b/include/mim/check.h
@@ -33,7 +33,6 @@ public:
     /// Def::flags is used to keep track of rank for
     /// [Union by rank](https://en.wikipedia.org/wiki/Disjoint-set_data_structure#Union_by_rank).
     static const Def* find(const Def*);
-    static const Def* refer(const Def*);
 
     Infer* stub(const Def* type) { return stub_(world(), type)->set(dbg()); }
     /// If unset, explode to Tuple.

--- a/include/mim/check.h
+++ b/include/mim/check.h
@@ -27,11 +27,12 @@ public:
     /// Def::flags is used to keep track of rank for
     /// [Union by rank](https://en.wikipedia.org/wiki/Disjoint-set_data_structure#Union_by_rank).
     static const Def* find(const Def*);
+    static const Def* refer(const Def*);
 
-    Infer* stub(Ref type) { return stub_(world(), type)->set(dbg()); }
+    Infer* stub(const Def* type) { return stub_(world(), type)->set(dbg()); }
     /// If unset, explode to Tuple.
     /// @returns the new Tuple, or `this` if unsuccessful.
-    Ref tuplefy();
+    const Def* tuplefy();
 
     static constexpr auto Node = Node::Infer;
 
@@ -39,8 +40,8 @@ private:
     flags_t rank() const { return flags(); }
     flags_t& rank() { return flags_; }
 
-    Ref rebuild_(World&, Ref, Defs) const override;
-    Infer* stub_(World&, Ref) override;
+    const Def* rebuild_(World&, const Def*, Defs) const override;
+    Infer* stub_(World&, const Def*) override;
 
     friend class World;
     friend class Checker;
@@ -62,27 +63,31 @@ public:
         Test,
     };
 
-    template<Mode mode> static bool alpha(Ref d1, Ref d2) { return Checker(d1->world()).alpha_<mode>(d1, d2); }
+    template<Mode mode> static bool alpha(const Def* d1, const Def* d2) {
+        return Checker(d1->world()).alpha_<mode>(d1, d2);
+    }
 
     /// Can @p value be assigned to sth of @p type?
     /// @note This is different from `equiv(type, value->type())` since @p type may be dependent.
-    [[nodiscard]] static Ref assignable(Ref type, Ref value) { return Checker(type->world()).assignable_(type, value); }
+    [[nodiscard]] static const Def* assignable(const Def* type, const Def* value) {
+        return Checker(type->world()).assignable_(type, value);
+    }
 
     /// Yields `defs.front()`, if all @p defs are Check::alpha-equivalent (`Mode::Test`) and `nullptr` otherwise.
-    static Ref is_uniform(Defs defs);
+    static const Def* is_uniform(Defs defs);
 
 private:
 #ifdef MIM_ENABLE_CHECKS
     template<Mode> bool fail();
-    Ref fail();
+    const Def* fail();
 #else
     template<Mode> bool fail() { return false; }
-    Ref fail() { return {}; }
+    const Def* fail() { return {}; }
 #endif
 
-    template<Mode> bool alpha_(Ref d1, Ref d2);
-    template<Mode> bool alpha_internal(Ref, Ref);
-    [[nodiscard]] Ref assignable_(Ref type, Ref value);
+    template<Mode> bool alpha_(const Def* d1, const Def* d2);
+    template<Mode> bool alpha_internal(const Def*, const Def*);
+    [[nodiscard]] const Def* assignable_(const Def* type, const Def* value);
 
     World& world_;
     MutMap<const Def*> binders_;

--- a/include/mim/check.h
+++ b/include/mim/check.h
@@ -18,8 +18,14 @@ public:
     /// @name op
     ///@{
     const Def* op() const { return Def::op(0); }
-    Infer* set(const Def* op) { return Def::set(0, op)->as<Infer>(); }
-    Infer* reset(const Def* op) { return Def::reset(0, op)->as<Infer>(); }
+    Infer* set(const Def* op) {
+        assert(op != this);
+        return Def::set(0, op)->as<Infer>();
+    }
+    Infer* reset(const Def* op) {
+        assert(op != this);
+        return Def::reset(0, op)->as<Infer>();
+    }
     Infer* unset() { return Def::unset()->as<Infer>(); }
     ///@}
 

--- a/include/mim/lam.h
+++ b/include/mim/lam.h
@@ -29,8 +29,8 @@ public:
     /// @anchor pi_dom
     /// @see @ref proj
     ///@{
-    Ref dom() const { return op(0); }
-    Ref codom() const { return op(1); }
+    const Def* dom() const { return op(0); }
+    const Def* codom() const { return op(1); }
     MIM_PROJ(dom, const)
     MIM_PROJ(codom, const)
     ///@}
@@ -41,19 +41,19 @@ public:
     ///@{
     // clang-format off
     /// Is this a continuation - i.e. is the Pi::codom mim::Bot%tom?
-    static const Pi* isa_cn(Ref d) { return d->isa<Pi>() && d->as<Pi>()->codom()->node() == Node::Bot ? d->as<Pi>() : nullptr; }
+    static const Pi* isa_cn(const Def* d) { return d->isa<Pi>() && d->as<Pi>()->codom()->node() == Node::Bot ? d->as<Pi>() : nullptr; }
     /// Is this a continuation (Pi::isa_cn) which has a Pi::ret_pi?
-    static const Pi* isa_returning(Ref d)  { return isa_cn(d) &&  d->as<Pi>()->ret_pi() ? d->as<Pi>() : nullptr; }
+    static const Pi* isa_returning(const Def* d)  { return isa_cn(d) &&  d->as<Pi>()->ret_pi() ? d->as<Pi>() : nullptr; }
     /// Is this a continuation (Pi::isa_cn) that is **not** Pi::isa_returning?
-    static const Pi* isa_basicblock(Ref d) { return isa_cn(d) && !d->as<Pi>()->ret_pi() ? d->as<Pi>() : nullptr; }
+    static const Pi* isa_basicblock(const Def* d) { return isa_cn(d) && !d->as<Pi>()->ret_pi() ? d->as<Pi>() : nullptr; }
     // clang-format on
     /// Is @p d an Pi::is_implicit (mutable) Pi?
-    static Pi* isa_implicit(Ref d) {
+    static Pi* isa_implicit(const Def* d) {
         if (auto pi = d->isa_mut<Pi>(); pi && pi->is_implicit()) return pi;
         return nullptr;
     }
     /// Yields the Pi::ret_pi() of @p d, if it is in fact a Pi.
-    static const Pi* has_ret_pi(Ref d) { return d->isa<Pi>() ? d->as<Pi>()->ret_pi() : nullptr; }
+    static const Pi* has_ret_pi(const Def* d) { return d->isa<Pi>() ? d->as<Pi>()->ret_pi() : nullptr; }
     ///@}
 
     /// @name Return Continuation
@@ -63,39 +63,39 @@ public:
     /// Yields the last Pi::dom, if Pi::isa_basicblock.
     const Pi* ret_pi() const;
     /// Pi::dom%ain of Pi::ret_pi.
-    Ref ret_dom() const { return ret_pi()->dom(); }
+    const Def* ret_dom() const { return ret_pi()->dom(); }
     ///@}
 
     /// @name Setters
     /// @see @ref set_ops "Setting Ops"
     ///@{
     using Setters<Pi>::set;
-    Pi* set(Ref dom, Ref codom) { return set_dom(dom)->set_codom(codom); }
-    Pi* set_dom(Ref dom) { return Def::set(0, dom)->as<Pi>(); }
+    Pi* set(const Def* dom, const Def* codom) { return set_dom(dom)->set_codom(codom); }
+    Pi* set_dom(const Def* dom) { return Def::set(0, dom)->as<Pi>(); }
     Pi* set_dom(Defs doms);
-    Pi* set_codom(Ref codom) { return Def::set(1, codom)->as<Pi>(); }
+    Pi* set_codom(const Def* codom) { return Def::set(1, codom)->as<Pi>(); }
     Pi* unset() { return Def::unset()->as<Pi>(); }
     ///@}
 
     /// @name Type Checking
     ///@{
-    Ref check(size_t, Ref) override;
-    Ref check() override;
-    static Ref infer(Ref dom, Ref codom);
+    const Def* check(size_t, const Def*) override;
+    const Def* check() override;
+    static const Def* infer(const Def* dom, const Def* codom);
     ///@}
 
     /// @name Rebuild
     ///@{
-    Ref reduce(Ref arg) const { return Def::reduce(1, arg); }
-    Pi* stub(Ref type) { return stub_(world(), type)->set(dbg()); }
+    const Def* reduce(const Def* arg) const { return Def::reduce(1, arg); }
+    Pi* stub(const Def* type) { return stub_(world(), type)->set(dbg()); }
     const Pi* immutabilize() override;
     ///@}
 
     static constexpr auto Node = Node::Pi;
 
 private:
-    Ref rebuild_(World&, Ref, Defs) const override;
-    Pi* stub_(World&, Ref) override;
+    const Def* rebuild_(World&, const Def*, Defs) const override;
+    Pi* stub_(World&, const Def*) override;
 
     friend class World;
 };
@@ -110,12 +110,12 @@ private:
         : Def(Node, pi, 2, 0) {}
 
 public:
-    using Filter = std::variant<bool, Ref>;
+    using Filter = std::variant<bool, const Def*>;
 
     /// @name ops
     ///@{
-    Ref filter() const { return op(0); }
-    Ref body() const { return op(1); }
+    const Def* filter() const { return op(0); }
+    const Def* body() const { return op(1); }
     ///@}
 
     /// @name type
@@ -123,8 +123,8 @@ public:
     /// @see @ref proj
     ///@{
     const Pi* type() const { return Def::type()->as<Pi>(); }
-    Ref dom() const { return type()->dom(); }
-    Ref codom() const { return type()->codom(); }
+    const Def* dom() const { return type()->dom(); }
+    const Def* codom() const { return type()->codom(); }
     MIM_PROJ(dom, const)
     MIM_PROJ(codom, const)
     ///@}
@@ -133,12 +133,12 @@ public:
     /// @see @ref continuations "Pi: Continuations"
     ///@{
     // clang-format off
-    static const Lam* isa_cn(Ref d) { return Pi::isa_cn(d->type()) ? d->isa<Lam>() : nullptr; }
-    static const Lam* isa_basicblock(Ref d) { return Pi::isa_basicblock(d->type()) ? d->isa<Lam>() : nullptr; }
-    static const Lam* isa_returning(Ref d)  { return Pi::isa_returning (d->type()) ? d->isa<Lam>() : nullptr; }
-    static Lam* isa_mut_cn(Ref d) { return isa_cn(d) ? d->isa_mut<Lam>() : nullptr; }                ///< Only for mutables.
-    static Lam* isa_mut_basicblock(Ref d) { return isa_basicblock(d) ? d->isa_mut<Lam>(): nullptr; } ///< Only for mutables.
-    static Lam* isa_mut_returning(Ref d)  { return isa_returning (d) ? d->isa_mut<Lam>(): nullptr; } ///< Only for mutables.
+    static const Lam* isa_cn(const Def* d) { return Pi::isa_cn(d->type()) ? d->isa<Lam>() : nullptr; }
+    static const Lam* isa_basicblock(const Def* d) { return Pi::isa_basicblock(d->type()) ? d->isa<Lam>() : nullptr; }
+    static const Lam* isa_returning(const Def* d)  { return Pi::isa_returning (d->type()) ? d->isa<Lam>() : nullptr; }
+    static Lam* isa_mut_cn(const Def* d) { return isa_cn(d) ? d->isa_mut<Lam>() : nullptr; }                ///< Only for mutables.
+    static Lam* isa_mut_basicblock(const Def* d) { return isa_basicblock(d) ? d->isa_mut<Lam>(): nullptr; } ///< Only for mutables.
+    static Lam* isa_mut_returning(const Def* d)  { return isa_returning (d) ? d->isa_mut<Lam>(): nullptr; } ///< Only for mutables.
     // clang-format on
     ///@}
 
@@ -146,9 +146,9 @@ public:
     /// @see @ref return_continuation "Pi: Return Continuation"
     ///@{
     const Pi* ret_pi() const { return type()->ret_pi(); }
-    Ref ret_dom() const { return ret_pi()->dom(); }
+    const Def* ret_dom() const { return ret_pi()->dom(); }
     /// Yields the Lam::var of the Lam::ret_pi.
-    Ref ret_var() { return type()->ret_pi() ? var(num_vars() - 1) : nullptr; }
+    const Def* ret_var() { return type()->ret_pi() ? var(num_vars() - 1) : nullptr; }
     ///@}
 
     /// @name Setters
@@ -161,32 +161,32 @@ public:
     /// @see @ref set_ops "Setting Ops"
     ///@{
     using Setters<Lam>::set;
-    Lam* set(Filter filter, Ref body) { return set_filter(filter)->set_body(body); }
-    Lam* set_filter(Filter);                                         ///< Set filter first.
-    Lam* set_body(Ref body) { return Def::set(1, body)->as<Lam>(); } ///< Set body second.
+    Lam* set(Filter filter, const Def* body) { return set_filter(filter)->set_body(body); }
+    Lam* set_filter(Filter);                                                ///< Set filter first.
+    Lam* set_body(const Def* body) { return Def::set(1, body)->as<Lam>(); } ///< Set body second.
     /// Set body to an App of @p callee and @p arg.
-    Lam* app(Filter filter, Ref callee, Ref arg);
+    Lam* app(Filter filter, const Def* callee, const Def* arg);
     /// Set body to an App of @p callee and @p args.
-    Lam* app(Filter filter, Ref callee, Defs args);
+    Lam* app(Filter filter, const Def* callee, Defs args);
     /// Set body to an App of `(f, t)#cond mem` or `(f, t)#cond ()` if @p mem is `nullptr`.
-    Lam* branch(Filter filter, Ref cond, Ref t, Ref f, Ref mem = nullptr);
-    Lam* test(Filter filter, Ref val, Ref idx, Ref match, Ref clash, Ref mem);
+    Lam* branch(Filter filter, const Def* cond, const Def* t, const Def* f, const Def* mem = nullptr);
+    Lam* test(Filter filter, const Def* val, const Def* idx, const Def* match, const Def* clash, const Def* mem);
     Lam* set(Defs ops) { return Def::set(ops)->as<Lam>(); }
     Lam* unset() { return Def::unset()->as<Lam>(); }
     ///@}
 
-    Lam* stub(Ref type) { return stub_(world(), type)->set(dbg()); }
+    Lam* stub(const Def* type) { return stub_(world(), type)->set(dbg()); }
 
     /// @name Type Checking
     ///@{
-    Ref check(size_t, Ref) override;
+    const Def* check(size_t, const Def*) override;
     ///@}
 
     static constexpr auto Node = Node::Lam;
 
 private:
-    Ref rebuild_(World&, Ref, Defs) const override;
-    Lam* stub_(World&, Ref) override;
+    const Def* rebuild_(World&, const Def*, Defs) const override;
+    Lam* stub_(World&, const Def*) override;
 
     friend class World;
 };
@@ -213,7 +213,7 @@ public:
 
     /// @name callee
     ///@{
-    Ref callee() const { return op(0); }
+    const Def* callee() const { return op(0); }
     const App* decurry() const { return callee()->as<App>(); } ///< Returns App::callee again as App.
     const Pi* callee_type() const { return callee()->type()->as<Pi>(); }
     ///@}
@@ -222,7 +222,7 @@ public:
     /// @anchor app_arg
     /// @see @ref proj
     ///@{
-    Ref arg() const { return op(1); }
+    const Def* arg() const { return op(1); }
     MIM_PROJ(arg, const)
     ///@}
 
@@ -236,14 +236,14 @@ public:
     static constexpr auto Node = Node::App;
 
 private:
-    Ref rebuild_(World&, Ref, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const override;
 
     friend class World;
 };
 
 /// @name Helpers to work with Functions
 ///@{
-inline const App* isa_callee(Ref def, size_t i) { return i == 0 ? def->isa<App>() : nullptr; }
+inline const App* isa_callee(const Def* def, size_t i) { return i == 0 ? def->isa<App>() : nullptr; }
 
 /// These are Lam%s that are neither `nullptr`, nor Lam::is_external, nor Lam::is_unset.
 inline Lam* isa_workable(Lam* lam) {
@@ -251,13 +251,13 @@ inline Lam* isa_workable(Lam* lam) {
     return lam;
 }
 
-inline std::pair<const App*, Lam*> isa_apped_mut_lam(Ref def) {
+inline std::pair<const App*, Lam*> isa_apped_mut_lam(const Def* def) {
     if (auto app = def->isa<App>()) return {app, app->callee()->isa_mut<Lam>()};
     return {nullptr, nullptr};
 }
 
 /// Yields curried App%s in a flat `std::deque<const App*>`.
-std::deque<const App*> decurry(Ref);
+std::deque<const App*> decurry(const Def*);
 
 /// The high level view is:
 /// ```
@@ -275,10 +275,10 @@ std::deque<const App*> decurry(Ref);
 /// h': Cn B
 /// h'= λ b = f (b, ret_h)
 /// ```
-Ref compose_cn(Ref f, Ref g);
+const Def* compose_cn(const Def* f, const Def* g);
 
 /// Helper function to cope with the fact that normalizers take all arguments and not only its axiom arguments.
-std::pair<Ref, DefVec> collect_args(Ref def);
+std::pair<const Def*, DefVec> collect_args(const Def* def);
 ///@}
 
 } // namespace mim

--- a/include/mim/lattice.h
+++ b/include/mim/lattice.h
@@ -19,7 +19,7 @@ public:
     /// @name Get Element by Type
     ///@{
     size_t find(const Def* type) const;
-    Ref get(const Def* type) const { return op(find(type)); }
+    const Def* get(const Def* type) const { return op(find(type)); }
     ///@}
 };
 
@@ -38,13 +38,13 @@ private:
 public:
     using Setters<TBound<Up>>::set;
 
-    TBound* stub(Ref type) { return stub_(world(), type)->set(dbg()); }
+    TBound* stub(const Def* type) { return stub_(world(), type)->set(dbg()); }
 
     static constexpr auto Node = Up ? Node::Join : Node::Meet;
 
 private:
-    Ref rebuild_(World&, Ref, Defs) const override;
-    TBound* stub_(World&, Ref) override;
+    const Def* rebuild_(World&, const Def*, Defs) const override;
+    TBound* stub_(World&, const Def*) override;
 
     friend class World;
 };
@@ -60,7 +60,7 @@ private:
     Ac(const Def* type, Defs defs)
         : Def(Node, type, defs, 0) {}
 
-    Ref rebuild_(World&, Ref, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const override;
 
     friend class World;
 };
@@ -77,13 +77,13 @@ public:
 
     /// @name ops
     ///@{
-    Ref value() const { return op(0); }
+    const Def* value() const { return op(0); }
     ///@}
 
     static constexpr auto Node = Node::Vel;
 
 private:
-    Ref rebuild_(World&, Ref, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const override;
 
     friend class World;
 };
@@ -99,13 +99,13 @@ public:
 
     /// @name ops
     ///@{
-    Ref value() const { return op(0); }
+    const Def* value() const { return op(0); }
     ///@}
 
     static constexpr auto Node = Node::Pick;
 
 private:
-    Ref rebuild_(World&, Ref, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const override;
 
     friend class World;
 };
@@ -133,14 +133,14 @@ public:
 
     /// @name ops
     ///@{
-    Ref value() const { return op(0); }
-    Ref probe() const { return op(1); }
-    Ref match() const { return op(2); }
-    Ref clash() const { return op(3); }
+    const Def* value() const { return op(0); }
+    const Def* probe() const { return op(1); }
+    const Def* match() const { return op(2); }
+    const Def* clash() const { return op(3); }
     ///@}
 
 private:
-    Ref rebuild_(World&, Ref, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const override;
 
     friend class World;
 };
@@ -161,13 +161,13 @@ private:
 public:
     using Setters<TExt<Up>>::set;
 
-    TExt* stub(Ref type) { return stub_(world(), type)->set(dbg()); }
+    TExt* stub(const Def* type) { return stub_(world(), type)->set(dbg()); }
 
     static constexpr auto Node = Up ? Node::Top : Node::Bot;
 
 private:
-    Ref rebuild_(World&, Ref, Defs) const override;
-    TExt* stub_(World&, Ref) override;
+    const Def* rebuild_(World&, const Def*, Defs) const override;
+    TExt* stub_(World&, const Def*) override;
 
     friend class World;
 };
@@ -193,13 +193,13 @@ public:
 
     /// @name ops
     ///@{
-    Ref inhabitant() const { return op(0); }
+    const Def* inhabitant() const { return op(0); }
     ///@}
 
     static constexpr auto Node = Node::Uniq;
 
 private:
-    Ref rebuild_(World&, Ref, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const override;
 
     friend class World;
 };

--- a/include/mim/pass/beta_red.h
+++ b/include/mim/pass/beta_red.h
@@ -16,9 +16,9 @@ public:
     void keep(Lam* lam) { keep_.emplace(lam); }
 
 private:
-    Ref rewrite(Ref) override;
+    const Def* rewrite(const Def*) override;
     undo_t analyze(const Proxy*) override;
-    undo_t analyze(Ref) override;
+    undo_t analyze(const Def*) override;
 
     LamSet keep_;
 };

--- a/include/mim/pass/eta_exp.h
+++ b/include/mim/pass/eta_exp.h
@@ -48,9 +48,9 @@ public:
 private:
     /// @name PassMan hooks
     ///@{
-    Ref rewrite(Ref) override;
+    const Def* rewrite(const Def*) override;
     undo_t analyze(const Proxy*) override;
-    undo_t analyze(Ref) override;
+    undo_t analyze(const Def*) override;
     ///@}
     Lam* eta_exp(Lam*); ///< Helper that peforms the actual η-expansion.
 

--- a/include/mim/pass/eta_red.h
+++ b/include/mim/pass/eta_red.h
@@ -23,7 +23,7 @@ public:
 
 private:
     const bool callee_only_;
-    Ref rewrite(Ref) override;
+    const Def* rewrite(const Def*) override;
     undo_t analyze(const Var*) override;
 
     LamSet irreducible_;

--- a/include/mim/pass/lam_spec.h
+++ b/include/mim/pass/lam_spec.h
@@ -12,7 +12,7 @@ public:
 private:
     /// @name PassMan hooks
     ///@{
-    Ref rewrite(Ref) override;
+    const Def* rewrite(const Def*) override;
     ///@}
 
     Def2Def old2new_;

--- a/include/mim/pass/scalarize.h
+++ b/include/mim/pass/scalarize.h
@@ -23,11 +23,11 @@ public:
         : RWPass(man, "scalarize")
         , eta_exp_(eta_exp) {}
 
-    Ref rewrite(Ref) override;
+    const Def* rewrite(const Def*) override;
 
 private:
     bool should_expand(Lam* lam);
-    Lam* make_scalar(Ref def);
+    Lam* make_scalar(const Def* def);
 
     EtaExp* eta_exp_;
     Lam2Lam tup2sca_;

--- a/include/mim/pass/tail_rec_elim.h
+++ b/include/mim/pass/tail_rec_elim.h
@@ -15,8 +15,8 @@ public:
 private:
     /// @name PassMan hooks
     ///@{
-    Ref rewrite(Ref) override;
-    undo_t analyze(Ref) override;
+    const Def* rewrite(const Def*) override;
+    undo_t analyze(const Def*) override;
     ///@}
 
     EtaRed* eta_red_;

--- a/include/mim/plug/affine/affine.h
+++ b/include/mim/plug/affine/affine.h
@@ -16,7 +16,8 @@ inline const Def* fn_for(World& w, Defs params) {
 
 /// Returns a fully applied affine_for axiom.
 /// See documentation for %affine.For axiom in @ref affine.
-inline const Def* op_for(World& w, Ref begin, Ref end, Ref step, Defs inits, Ref body, Ref brk) {
+inline const Def*
+op_for(World& w, const Def* begin, const Def* end, const Def* step, Defs inits, const Def* body, const Def* brk) {
     auto types = DefVec(inits.size(), [&](size_t i) { return inits[i]->type(); });
     return w.app(fn_for(w, types), {begin, end, step, w.tuple(inits), body, brk});
 }

--- a/include/mim/plug/affine/pass/lower_for.h
+++ b/include/mim/plug/affine/pass/lower_for.h
@@ -31,7 +31,7 @@ public:
     LowerFor(PassMan& man)
         : RWPass(man, "lower_affine_for") {}
 
-    Ref rewrite(Ref) override;
+    const Def* rewrite(const Def*) override;
 
 private:
     Def2Def rewritten_;

--- a/include/mim/plug/autodiff/pass/autodiff_eval.h
+++ b/include/mim/plug/autodiff/pass/autodiff_eval.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mim/def.h>
+
 #include <mim/pass/pass.h>
 
 namespace mim::plug::autodiff {
@@ -13,13 +14,13 @@ public:
         : RWPass(man, "autodiff_eval") {}
 
     /// Detect autodiff calls.
-    Ref rewrite(Ref) override;
+    const Def* rewrite(const Def*) override;
 
     /// Acts on toplevel autodiff on closed terms:
     /// * Replaces lambdas, operators with the appropriate derivatives.
     /// * Creates new lambda, calls associate variables, init maps, calls augment.
-    Ref derive(Ref);
-    Ref derive_(Ref);
+    const Def* derive(const Def*);
+    const Def* derive_(const Def*);
 
     /// Applies to (open) expressions in a functional context.
     /// Returns the rewritten expressions and augments the partial and modular pullbacks.
@@ -27,16 +28,16 @@ public:
     /// Otherwise, only pullbacks are added.
     /// To do so, some calls (e.g. axioms) are replaced by their derivatives.
     /// This transformation can be seen as an augmentation with a dual computation that generates the derivatives.
-    Ref augment(Ref, Lam*, Lam*);
-    Ref augment_(Ref, Lam*, Lam*);
+    const Def* augment(const Def*, Lam*, Lam*);
+    const Def* augment_(const Def*, Lam*, Lam*);
     /// helper functions for augment
-    Ref augment_var(const Var*, Lam*, Lam*);
-    Ref augment_lam(Lam*, Lam*, Lam*);
-    Ref augment_extract(const Extract*, Lam*, Lam*);
-    Ref augment_app(const App*, Lam*, Lam*);
-    Ref augment_lit(const Lit*, Lam*, Lam*);
-    Ref augment_tuple(const Tuple*, Lam*, Lam*);
-    Ref augment_pack(const Pack* pack, Lam* f, Lam* f_diff);
+    const Def* augment_var(const Var*, Lam*, Lam*);
+    const Def* augment_lam(Lam*, Lam*, Lam*);
+    const Def* augment_extract(const Extract*, Lam*, Lam*);
+    const Def* augment_app(const App*, Lam*, Lam*);
+    const Def* augment_lit(const Lit*, Lam*, Lam*);
+    const Def* augment_tuple(const Tuple*, Lam*, Lam*);
+    const Def* augment_pack(const Pack* pack, Lam* f, Lam* f_diff);
 
 private:
     /// Transforms closed terms (lambda, operator) to derived expressions.

--- a/include/mim/plug/autodiff/pass/autodiff_zero.h
+++ b/include/mim/plug/autodiff/pass/autodiff_zero.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mim/def.h>
+
 #include <mim/pass/pass.h>
 
 namespace mim::plug::autodiff {
@@ -11,7 +12,7 @@ public:
     AutoDiffZero(PassMan& man)
         : RWPass(man, "autodiff_zero") {}
 
-    Ref rewrite(Ref) override;
+    const Def* rewrite(const Def*) override;
 };
 
 } // namespace mim::plug::autodiff

--- a/include/mim/plug/autodiff/pass/autodiff_zero_cleanup.h
+++ b/include/mim/plug/autodiff/pass/autodiff_zero_cleanup.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mim/def.h>
+
 #include <mim/pass/pass.h>
 
 namespace mim::plug::autodiff {
@@ -11,7 +12,7 @@ public:
     AutoDiffZeroCleanup(PassMan& man)
         : RWPass(man, "autodiff_zero_cleanup") {}
 
-    Ref rewrite(Ref) override;
+    const Def* rewrite(const Def*) override;
 };
 
 } // namespace mim::plug::autodiff

--- a/include/mim/plug/clos/clos.h
+++ b/include/mim/plug/clos/clos.h
@@ -19,15 +19,15 @@ public:
         return def_->type()->isa<Sigma>();
     }
 
-    Ref env();
-    Ref env_type() { return env()->type(); }
+    const Def* env();
+    const Def* env_type() { return env()->type(); }
 
-    Ref fnc();
+    const Def* fnc();
     const Pi* fnc_type() { return fnc()->type()->isa<Pi>(); }
     Lam* fnc_as_lam();
 
-    Ref env_var();
-    Ref ret_var() { return fnc_as_lam()->ret_var(); }
+    const Def* env_var();
+    const Def* ret_var() { return fnc_as_lam()->ret_var(); }
     ///@}
 
     explicit operator bool() const { return def_ != nullptr; }
@@ -53,30 +53,30 @@ private:
     const Tuple* def_;
     const attr attr_;
 
-    friend ClosLit isa_clos_lit(Ref, bool);
+    friend ClosLit isa_clos_lit(const Def*, bool);
 };
 
 /// Tries to match a closure literal.
-ClosLit isa_clos_lit(Ref def, bool fn_isa_lam = true);
+ClosLit isa_clos_lit(const Def* def, bool fn_isa_lam = true);
 
 /// Pack a typed closure. This assumes that @p fn expects the environment as its Clos_Env_Param%th argument.
-Ref clos_pack(Ref env, Ref fn, Ref ct = nullptr);
+const Def* clos_pack(const Def* env, const Def* fn, const Def* ct = nullptr);
 
 /// Deconstruct a closure into `(env_type, function, env)`.
 /// **Important**: use this or ClosLit to destruct closures, since typechecking dependent pairs is currently
 /// broken.
-std::tuple<Ref, Ref, Ref> clos_unpack(Ref c);
+std::tuple<const Def*, const Def*, const Def*> clos_unpack(const Def* c);
 
 /// Apply a closure to arguments.
-Ref clos_apply(Ref closure, Ref args);
-inline Ref apply_closure(Ref closure, Defs args) {
+const Def* clos_apply(const Def* closure, const Def* args);
+inline const Def* apply_closure(const Def* closure, Defs args) {
     auto& w = closure->world();
     return clos_apply(closure, w.tuple(args));
 }
 
 // TODO: rename this
 /// Checks is def is the variable of a mut of type N.
-template<class N> std::tuple<const Extract*, N*> ca_isa_var(Ref def) {
+template<class N> std::tuple<const Extract*, N*> ca_isa_var(const Def* def) {
     if (auto proj = def->isa<Extract>()) {
         if (auto var = proj->tuple()->isa<Var>(); var && var->mut()->isa<N>())
             return std::tuple(proj, var->mut()->as<N>());
@@ -88,14 +88,14 @@ template<class N> std::tuple<const Extract*, N*> ca_isa_var(Ref def) {
 /// @name Closure Types
 ///@{
 /// Returns @p def if @p def is a closure and @c nullptr otherwise
-const Sigma* isa_clos_type(Ref def);
+const Sigma* isa_clos_type(const Def* def);
 
 /// Creates a typed closure type from @p pi.
 Sigma* clos_type(const Pi* pi);
 
 /// Convert a closure type to a Pi, where the environment type has been removed or replaced by @p new_env_type
 /// (if @p new_env_type != @c nullptr)
-const Pi* clos_type_to_pi(Ref ct, Ref new_env_type = nullptr);
+const Pi* clos_type_to_pi(const Def* ct, const Def* new_env_type = nullptr);
 
 ///@}
 
@@ -113,30 +113,32 @@ inline size_t shift_env(size_t i) { return (i < Clos_Env_Param) ? i : i - 1_u64;
 inline size_t skip_env(size_t i) { return (i < Clos_Env_Param) ? i : i + 1_u64; }
 
 // TODO what does this do exactly?
-Ref ctype(World& w, Defs doms, Ref env_type = nullptr);
+const Def* ctype(World& w, Defs doms, const Def* env_type = nullptr);
 
-Ref clos_insert_env(size_t i, Ref env, std::function<Ref(size_t)> f);
-inline Ref clos_insert_env(size_t i, Ref env, Ref a) {
+const Def* clos_insert_env(size_t i, const Def* env, std::function<const Def*(size_t)> f);
+inline const Def* clos_insert_env(size_t i, const Def* env, const Def* a) {
     return clos_insert_env(i, env, [&](auto i) { return a->proj(i); });
 }
 
-inline Ref clos_insert_env(Ref env, Ref tup_or_sig) {
+inline const Def* clos_insert_env(const Def* env, const Def* tup_or_sig) {
     auto& w      = tup_or_sig->world();
     auto new_ops = DefVec(tup_or_sig->num_projs() + 1, [&](auto i) { return clos_insert_env(i, env, tup_or_sig); });
     return (tup_or_sig->isa<Sigma>()) ? w.sigma(new_ops) : w.tuple(new_ops);
 }
 
-Ref clos_remove_env(size_t i, std::function<Ref(size_t)> f);
-inline Ref clos_remove_env(size_t i, Ref def) {
+const Def* clos_remove_env(size_t i, std::function<const Def*(size_t)> f);
+inline const Def* clos_remove_env(size_t i, const Def* def) {
     return clos_remove_env(i, [&](auto i) { return def->proj(i); });
 }
-inline Ref clos_remove_env(Ref tup_or_sig) {
+inline const Def* clos_remove_env(const Def* tup_or_sig) {
     auto& w      = tup_or_sig->world();
     auto new_ops = DefVec(tup_or_sig->num_projs() - 1, [&](auto i) { return clos_remove_env(i, tup_or_sig); });
     return (tup_or_sig->isa<Sigma>()) ? w.sigma(new_ops) : w.tuple(new_ops);
 }
 
-inline Ref clos_sub_env(Ref tup_or_sig, Ref new_env) { return tup_or_sig->refine(Clos_Env_Param, new_env); }
+inline const Def* clos_sub_env(const Def* tup_or_sig, const Def* new_env) {
+    return tup_or_sig->refine(Clos_Env_Param, new_env);
+}
 ///@}
 
 } // namespace mim::plug::clos

--- a/include/mim/plug/clos/pass/branch_clos_elim.h
+++ b/include/mim/plug/clos/pass/branch_clos_elim.h
@@ -13,7 +13,7 @@ public:
         : RWPass(man, "branch_clos_elim")
         , branch2dropped_() {}
 
-    Ref rewrite(Ref) override;
+    const Def* rewrite(const Def*) override;
 
 private:
     DefMap<Lam*> branch2dropped_;

--- a/include/mim/plug/clos/pass/clos2sjlj.h
+++ b/include/mim/plug/clos/pass/clos2sjlj.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mim/pass/pass.h>
+
 #include <mim/plug/mem/mem.h>
 
 #include "mim/plug/clos/clos.h"
@@ -17,29 +18,29 @@ public:
         , ignore_() {}
 
     void enter() override;
-    Ref rewrite(Ref) override;
+    const Def* rewrite(const Def*) override;
 
 private:
-    Ref void_ptr() { return world().annex<clos::BufPtr>(); }
-    Ref jb_type() { return void_ptr(); }
-    Ref rb_type() { return world().call<mem::Ptr0>(void_ptr()); }
-    Ref tag_type() { return world().type_i32(); }
+    const Def* void_ptr() { return world().annex<clos::BufPtr>(); }
+    const Def* jb_type() { return void_ptr(); }
+    const Def* rb_type() { return world().call<mem::Ptr0>(void_ptr()); }
+    const Def* tag_type() { return world().type_i32(); }
 
-    Lam* get_throw(Ref res_type);
-    Lam* get_lpad(Lam* lam, Ref rb);
+    Lam* get_throw(const Def* res_type);
+    Lam* get_lpad(Lam* lam, const Def* rb);
 
     void get_exn_closures();
-    void get_exn_closures(Ref def, DefSet& visited);
+    void get_exn_closures(const Def* def, DefSet& visited);
 
     // clang-format off
-    LamMap<std::pair<int, Ref>> lam2tag_;
+    LamMap<std::pair<int, const Def*>> lam2tag_;
     DefMap<Lam*> dom2throw_;
     DefMap<Lam*> lam2lpad_;
     LamSet ignore_;
     // clang-format on
 
-    Ref cur_rbuf_ = nullptr;
-    Ref cur_jbuf_ = nullptr;
+    const Def* cur_rbuf_ = nullptr;
+    const Def* cur_jbuf_ = nullptr;
 };
 
 } // namespace mim::plug::clos

--- a/include/mim/plug/clos/pass/clos_conv_prep.h
+++ b/include/mim/plug/clos/pass/clos_conv_prep.h
@@ -19,7 +19,7 @@ public:
         , lam2fscope_() {}
 
     void enter() override;
-    Ref rewrite(Ref) override;
+    const Def* rewrite(const Def*) override;
     const App* rewrite_arg(const App* app);
     const App* rewrite_callee(const App* app);
 
@@ -31,9 +31,9 @@ public:
         return scope(lam) && scope(lam) != scope(curr_mut());
     }
 
-    bool from_outer_scope(Ref lam) { return curr_mut()->free_vars().has_intersection(lam->free_vars()); }
+    bool from_outer_scope(const Def* lam) { return curr_mut()->free_vars().has_intersection(lam->free_vars()); }
 
-    Ref eta_wrap(Ref def, attr a) {
+    const Def* eta_wrap(const Def* def, attr a) {
         auto& w                = world();
         auto [entry, inserted] = old2wrapper_.emplace(def, nullptr);
         auto& wrapper          = entry->second;

--- a/include/mim/plug/clos/pass/lower_typed_clos_prep.h
+++ b/include/mim/plug/clos/pass/lower_typed_clos_prep.h
@@ -13,14 +13,14 @@ public:
         : FPPass<LowerTypedClosPrep, Lam>(man, "lower_typed_clos_prep") {}
 
 private:
-    Ref rewrite(Ref) override;
-    undo_t analyze(Ref) override;
+    const Def* rewrite(const Def*) override;
+    undo_t analyze(const Def*) override;
 
-    bool is_esc(Ref def) {
+    bool is_esc(const Def* def) {
         if (auto [_, lam] = ca_isa_var<Lam>(def); lam && !lam->is_set()) return true;
         return esc_.contains(def);
     }
-    undo_t set_esc(Ref);
+    undo_t set_esc(const Def*);
 
     DefSet esc_;
 };

--- a/include/mim/plug/core/core.h
+++ b/include/mim/plug/core/core.h
@@ -17,12 +17,12 @@ enum class Mode : nat_t {
     nusw = nuw | nsw,
 };
 
-/// Give Mode as mim::plug::math::Mode, mim::nat_t or Ref.
-using VMode = std::variant<Mode, nat_t, Ref>;
+/// Give Mode as mim::plug::math::Mode, mim::nat_t or const Def*.
+using VMode = std::variant<Mode, nat_t, const Def*>;
 
-/// mim::plug::core::VMode -> Ref.
-inline Ref mode(World& w, VMode m) {
-    if (auto def = std::get_if<Ref>(&m)) return *def;
+/// mim::plug::core::VMode -> const Def*.
+inline const Def* mode(World& w, VMode m) {
+    if (auto def = std::get_if<const Def*>(&m)) return *def;
     if (auto nat = std::get_if<nat_t>(&m)) return w.lit_nat(*nat);
     return w.lit_nat((nat_t)std::get<Mode>(m));
 }
@@ -30,7 +30,7 @@ inline Ref mode(World& w, VMode m) {
 
 /// @name %%core.trait
 ///@{
-inline Ref op(trait o, Ref type) {
+inline const Def* op(trait o, const Def* type) {
     World& w = type->world();
     return w.app(w.annex(o), type);
 }
@@ -38,7 +38,7 @@ inline Ref op(trait o, Ref type) {
 
 /// @name %%core.pe
 ///@{
-inline Ref op(pe o, Ref def) {
+inline const Def* op(pe o, const Def* def) {
     World& w = def->world();
     return w.app(w.app(w.annex(o), def->type()), def);
 }
@@ -57,11 +57,11 @@ constexpr std::array<std::array<u64, 2>, 2> make_truth_table(bit2 id) {
 
 /// @name extract_unsafe
 ///@{
-inline Ref extract_unsafe(Ref d, Ref i) {
+inline const Def* extract_unsafe(const Def* d, const Def* i) {
     World& w = d->world();
     return w.extract(d, w.call(conv::u, d->unfold_type()->arity(), i));
 }
-inline Ref extract_unsafe(Ref d, u64 i) {
+inline const Def* extract_unsafe(const Def* d, u64 i) {
     World& w = d->world();
     return extract_unsafe(d, w.lit_idx(0_u64, i));
 }
@@ -69,11 +69,11 @@ inline Ref extract_unsafe(Ref d, u64 i) {
 
 /// @name insert_unsafe
 ///@{
-inline Ref insert_unsafe(Ref d, Ref i, Ref val) {
+inline const Def* insert_unsafe(const Def* d, const Def* i, const Def* val) {
     World& w = d->world();
     return w.insert(d, w.call(conv::u, d->unfold_type()->arity(), i), val);
 }
-inline Ref insert_unsafe(Ref d, u64 i, Ref val) {
+inline const Def* insert_unsafe(const Def* d, u64 i, const Def* val) {
     World& w = d->world();
     return insert_unsafe(d, w.lit_idx(0_u64, i), val);
 }

--- a/include/mim/plug/direct/direct.h
+++ b/include/mim/plug/direct/direct.h
@@ -12,7 +12,7 @@ namespace mim::plug::direct {
 /// let f: [t: T] → U = %direct.cps2ds_dep (T, lm (t': T): * = [t → t']U) k;
 /// ```
 ///@{
-inline Ref op_cps2ds_dep(Ref k) {
+inline const Def* op_cps2ds_dep(const Def* k) {
     auto& w   = k->world();
     auto K    = Pi::isa_cn(k->type());
     auto T    = K->dom(2, 0);

--- a/include/mim/plug/direct/pass/ds2cps.h
+++ b/include/mim/plug/direct/pass/ds2cps.h
@@ -23,12 +23,12 @@ public:
     DS2CPS(PassMan& man)
         : RWPass(man, "ds2cps") {}
 
-    Ref rewrite(Ref) override;
+    const Def* rewrite(const Def*) override;
 
 private:
     Def2Def rewritten_;
 
-    Ref rewrite_lam(Lam* lam);
+    const Def* rewrite_lam(Lam* lam);
 };
 
 } // namespace mim::plug::direct

--- a/include/mim/plug/math/math.h
+++ b/include/mim/plug/math/math.h
@@ -39,12 +39,12 @@ enum class Mode : nat_t {
 };
 // clang-format on
 
-/// Give Mode as mim::plug::math::Mode, mim::nat_t or Ref.
-using VMode = std::variant<Mode, nat_t, Ref>;
+/// Give Mode as mim::plug::math::Mode, mim::nat_t or const Def*.
+using VMode = std::variant<Mode, nat_t, const Def*>;
 
-/// mim::plug::math::VMode -> Ref.
-inline Ref mode(World& w, VMode m) {
-    if (auto def = std::get_if<Ref>(&m)) return *def;
+/// mim::plug::math::VMode -> const Def*.
+inline const Def* mode(World& w, VMode m) {
+    if (auto def = std::get_if<const Def*>(&m)) return *def;
     if (auto nat = std::get_if<nat_t>(&m)) return w.lit_nat(*nat);
     return w.lit_nat((nat_t)std::get<Mode>(m));
 }
@@ -52,16 +52,16 @@ inline Ref mode(World& w, VMode m) {
 
 /// @name %%math.F
 ///@{
-inline Ref type_f(Ref pe) {
+inline const Def* type_f(const Def* pe) {
     World& w = pe->world();
     return w.app(w.annex<F>(), pe);
 }
-inline Ref type_f(World& w, nat_t p, nat_t e) {
+inline const Def* type_f(World& w, nat_t p, nat_t e) {
     auto lp = w.lit_nat(p);
     auto le = w.lit_nat(e);
     return type_f(w.tuple({lp, le}));
 }
-template<nat_t P, nat_t E> inline auto match_f(Ref def) {
+template<nat_t P, nat_t E> inline auto match_f(const Def* def) {
     if (auto f_ty = match<F>(def)) {
         auto [p, e] = f_ty->arg()->projs<2>([](auto op) { return Lit::isa(op); });
         if (p && e && *p == P && *e == E) return f_ty;
@@ -69,11 +69,11 @@ template<nat_t P, nat_t E> inline auto match_f(Ref def) {
     return Match<F, App>();
 }
 
-inline auto match_f16(Ref def) { return match_f<10, 5>(def); }
-inline auto match_f32(Ref def) { return match_f<23, 8>(def); }
-inline auto match_f64(Ref def) { return match_f<52, 11>(def); }
+inline auto match_f16(const Def* def) { return match_f<10, 5>(def); }
+inline auto match_f32(const Def* def) { return match_f<23, 8>(def); }
+inline auto match_f64(const Def* def) { return match_f<52, 11>(def); }
 
-inline std::optional<nat_t> isa_f(Ref def) {
+inline std::optional<nat_t> isa_f(const Def* def) {
     if (auto f_ty = match<F>(def)) {
         if (auto [p, e] = f_ty->arg()->projs<2>([](auto op) { return Lit::isa(op); }); p && e) {
             if (*p == 10 && e == 5) return 16;
@@ -108,7 +108,7 @@ inline const Lit* lit_f(World& w, nat_t width, mim::f64 val) {
 
 /// @name %%math.arith
 ///@{
-inline Ref op_rminus(VMode m, Ref a) {
+inline const Def* op_rminus(VMode m, const Def* a) {
     World& w = a->world();
     auto s   = isa_f(a->type());
     return w.call(arith::sub, mode(w, m), Defs{lit_f(w, *s, -0.0), a});

--- a/include/mim/plug/matrix/matrix.h
+++ b/include/mim/plug/matrix/matrix.h
@@ -11,12 +11,12 @@ namespace mim::plug::matrix {
 #define INTERNAL_PREFIX "internal_mapRed_"
 
 /// %mat.zero: [n: Nat, S: «n; Nat», m: Nat] -> %mat.Mat (n,S,(Idx m));
-inline const Def* zero_int(World& w, Ref n, Ref S, Ref mem, nat_t m) {
+inline const Def* zero_int(World& w, const Def* n, const Def* S, const Def* mem, nat_t m) {
     // TODO: use mim definition by name
     return w.app(w.annex<matrix::constMat>(), {n, S, w.type_idx(m), mem, w.lit_idx(m, 0)});
 }
 
-inline const Def* op_read(Ref mem, Ref matrix, Ref idx) {
+inline const Def* op_read(const Def* mem, const Def* matrix, const Def* idx) {
     auto& world = matrix->world();
     auto mat_ty = match<Mat>(matrix->type());
     if (!mat_ty) return matrix;

--- a/include/mim/plug/matrix/pass/lower_matrix_highlevel.h
+++ b/include/mim/plug/matrix/pass/lower_matrix_highlevel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mim/def.h>
+
 #include <mim/pass/pass.h>
 
 namespace mim::plug::matrix {
@@ -17,8 +18,8 @@ public:
 
     /// custom rewrite function
     /// memoized version of rewrite_
-    Ref rewrite(Ref) override;
-    Ref rewrite_(Ref);
+    const Def* rewrite(const Def*) override;
+    const Def* rewrite_(const Def*);
 
 private:
     Def2Def rewritten;

--- a/include/mim/plug/matrix/pass/lower_matrix_lowlevel.h
+++ b/include/mim/plug/matrix/pass/lower_matrix_lowlevel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mim/def.h>
+
 #include <mim/pass/pass.h>
 #include <mim/phase/phase.h>
 
@@ -18,7 +19,7 @@ public:
     LowerMatrixLowLevel(World& world)
         : RWPhase(world, "lower_matrix_lowlevel") {}
 
-    Ref rewrite_imm(Ref) override;
+    const Def* rewrite_imm(const Def*) override;
 
 private:
     Def2Def rewritten;

--- a/include/mim/plug/matrix/pass/lower_matrix_mediumlevel.h
+++ b/include/mim/plug/matrix/pass/lower_matrix_mediumlevel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mim/def.h>
+
 #include <mim/pass/pass.h>
 
 namespace mim::plug::matrix {
@@ -49,8 +50,8 @@ public:
 
     /// custom rewrite function
     /// memoized version of rewrite_
-    Ref rewrite(Ref) override;
-    Ref rewrite_(Ref);
+    const Def* rewrite(const Def*) override;
+    const Def* rewrite_(const Def*);
 
 private:
     Def2Def rewritten;

--- a/include/mim/plug/mem/pass/alloc2malloc.h
+++ b/include/mim/plug/mem/pass/alloc2malloc.h
@@ -9,7 +9,7 @@ public:
     Alloc2Malloc(PassMan& man)
         : RWPass(man, "alloc2malloc") {}
 
-    Ref rewrite(Ref) override;
+    const Def* rewrite(const Def*) override;
 };
 
 } // namespace mim::plug::mem

--- a/include/mim/plug/mem/pass/copy_prop.h
+++ b/include/mim/plug/mem/pass/copy_prop.h
@@ -38,7 +38,7 @@ private:
 
     /// @name PassMan hooks
     ///@{
-    Ref rewrite(Ref) override;
+    const Def* rewrite(const Def*) override;
     undo_t analyze(const Proxy*) override;
     ///@}
 

--- a/include/mim/plug/mem/pass/remem_elim.h
+++ b/include/mim/plug/mem/pass/remem_elim.h
@@ -9,7 +9,7 @@ public:
     RememElim(PassMan& man)
         : RWPass(man, "remem_elim") {}
 
-    Ref rewrite(Ref) override;
+    const Def* rewrite(const Def*) override;
 };
 
 } // namespace mim::plug::mem

--- a/include/mim/plug/mem/pass/ssa_constr.h
+++ b/include/mim/plug/mem/pass/ssa_constr.h
@@ -31,17 +31,17 @@ private:
     /// @name PassMan hooks
     ///@{
     void enter() override;
-    Ref rewrite(const Proxy*) override;
-    Ref rewrite(Ref) override;
+    const Def* rewrite(const Proxy*) override;
+    const Def* rewrite(const Def*) override;
     undo_t analyze(const Proxy*) override;
-    undo_t analyze(Ref) override;
+    undo_t analyze(const Def*) override;
     ///@}
 
     /// @name SSA construction helpers - see paper
     ///@{
-    Ref get_val(Lam*, const Proxy*);
-    Ref set_val(Lam*, const Proxy*, Ref);
-    Ref mem2phi(const App*, Lam*);
+    const Def* get_val(Lam*, const Proxy*);
+    const Def* set_val(Lam*, const Proxy*, const Def*);
+    const Def* mem2phi(const App*, Lam*);
     ///@}
 
     EtaExp* eta_exp_;

--- a/include/mim/plug/refly/pass/remove_perm.h
+++ b/include/mim/plug/refly/pass/remove_perm.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mim/def.h>
+
 #include <mim/pass/pass.h>
 
 namespace mim::plug::refly {
@@ -11,7 +12,7 @@ public:
     RemoveDbgPerm(PassMan& man)
         : RWPass(man, "remove_dbg_perm") {}
 
-    Ref rewrite(Ref) override;
+    const Def* rewrite(const Def*) override;
 };
 
 } // namespace mim::plug::refly

--- a/include/mim/plug/regex/dfa2matcher.h
+++ b/include/mim/plug/regex/dfa2matcher.h
@@ -5,4 +5,4 @@
 #include "mim/plug/regex/regex.h"
 
 /// You can dl::get this function.
-extern "C" MIM_EXPORT const mim::Def* dfa2matcher(mim::World&, const automaton::DFA&, mim::Ref);
+extern "C" MIM_EXPORT const mim::Def* dfa2matcher(mim::World&, const automaton::DFA&, const mim::Def*);

--- a/include/mim/plug/regex/pass/lower_regex.h
+++ b/include/mim/plug/regex/pass/lower_regex.h
@@ -9,7 +9,7 @@ public:
     LowerRegex(PassMan& man)
         : RWPass(man, "lower_regex") {}
 
-    Ref rewrite(Ref) override;
+    const Def* rewrite(const Def*) override;
 };
 
 } // namespace mim::plug::regex

--- a/include/mim/plug/regex/regex2nfa.h
+++ b/include/mim/plug/regex/regex2nfa.h
@@ -6,13 +6,13 @@
 
 /// You can dl::get this function.
 /// @returns a raw pointer to automanton::NFA; use mim::regex::regex2nfa to pack it into a `std::unique_ptr`.
-extern "C" MIM_EXPORT automaton::NFA* regex2nfa(mim::Ref regex);
+extern "C" MIM_EXPORT automaton::NFA* regex2nfa(const mim::Def* regex);
 
 namespace mim::plug::regex {
 
-std::unique_ptr<automaton::NFA> regex2nfa(Ref regex);
+std::unique_ptr<automaton::NFA> regex2nfa(const Def* regex);
 
-inline std::unique_ptr<automaton::NFA> regex2nfa(decltype(::regex2nfa)* fptr, Ref regex) {
+inline std::unique_ptr<automaton::NFA> regex2nfa(decltype(::regex2nfa)* fptr, const Def* regex) {
     return std::unique_ptr<automaton::NFA>(fptr(regex), std::default_delete<automaton::NFA>());
 }
 

--- a/include/mim/rewrite.h
+++ b/include/mim/rewrite.h
@@ -13,14 +13,14 @@ public:
 
     World& world() { return world_; }
     /// Map @p old_def to @p new_def and returns @p new_def;
-    Ref map(Ref old_def, Ref new_def) { return old2new_[old_def] = new_def; }
+    const Def* map(const Def* old_def, const Def* new_def) { return old2new_[old_def] = new_def; }
 
     /// @name rewrite
     /// Recursively rewrite old Def%s.
     ///@{
-    virtual Ref rewrite(Ref);
-    virtual Ref rewrite_imm(Ref);
-    virtual Ref rewrite_mut(Def*);
+    virtual const Def* rewrite(const Def*);
+    virtual const Def* rewrite_imm(const Def*);
+    virtual const Def* rewrite_mut(Def*);
     ///@}
 
 private:
@@ -30,19 +30,19 @@ private:
 
 class VarRewriter : public Rewriter {
 public:
-    VarRewriter(const Var* var, Ref arg)
+    VarRewriter(const Var* var, const Def* arg)
         : Rewriter(arg->world())
         , vars_(var ? Vars(var) : Vars()) {
         if (var) map(var, arg);
     }
 
-    Ref rewrite_imm(Ref imm) override {
+    const Def* rewrite_imm(const Def* imm) override {
         if (imm->local_vars().empty() && imm->local_muts().empty()) return imm; // safe to skip
         if (imm->has_dep(Dep::Infer) || vars_.has_intersection(imm->free_vars())) return Rewriter::rewrite_imm(imm);
         return imm;
     }
 
-    Ref rewrite_mut(Def* mut) override {
+    const Def* rewrite_mut(Def* mut) override {
         if (vars_.has_intersection(mut->free_vars())) {
             if (auto var = mut->has_var()) vars_ = world().vars().insert(vars_, var);
             return Rewriter::rewrite_mut(mut);

--- a/include/mim/schedule.h
+++ b/include/mim/schedule.h
@@ -4,7 +4,7 @@
 
 namespace mim {
 
-/// References a user.
+/// const Def*erences a user.
 /// A Def `u` which uses Def `d` as `i^th` operand is a Use with Use::index `i` of Def `d`.
 class Use {
 public:

--- a/include/mim/tuple.h
+++ b/include/mim/tuple.h
@@ -26,21 +26,21 @@ public:
     /// @name Rebuild
     ///@{
     const Def* immutabilize() override;
-    Sigma* stub(Ref type) { return stub_(world(), type)->set(dbg()); }
+    Sigma* stub(const Def* type) { return stub_(world(), type)->set(dbg()); }
     ///@}
 
     /// @name Type Checking
     ///@{
-    Ref check(size_t, Ref) override;
-    Ref check() override;
-    static Ref infer(World&, Defs);
+    const Def* check(size_t, const Def*) override;
+    const Def* check() override;
+    static const Def* infer(World&, Defs);
     ///@}
 
     static constexpr auto Node = Node::Sigma;
 
 private:
-    Ref rebuild_(World&, Ref, Defs) const override;
-    Sigma* stub_(World&, Ref) override;
+    const Def* rebuild_(World&, const Def*, Defs) const override;
+    Sigma* stub_(World&, const Def*) override;
 
     friend class World;
 };
@@ -56,7 +56,7 @@ private:
     Tuple(const Def* type, Defs args)
         : Def(Node, type, args, 0) {}
 
-    Ref rebuild_(World&, Ref, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const override;
 
     friend class World;
 };
@@ -74,37 +74,37 @@ private:
 public:
     /// @name ops
     ///@{
-    Ref shape() const { return op(0); }
-    Ref body() const { return op(1); }
+    const Def* shape() const { return op(0); }
+    const Def* body() const { return op(1); }
     ///@}
 
     /// @name Setters
     /// @see @ref set_ops "Setting Ops"
     ///@{
     using Setters<Arr>::set;
-    Arr* set_shape(Ref shape) { return Def::set(0, shape)->as<Arr>(); }
-    Arr* set_body(Ref body) { return Def::set(1, body)->as<Arr>(); }
+    Arr* set_shape(const Def* shape) { return Def::set(0, shape)->as<Arr>(); }
+    Arr* set_body(const Def* body) { return Def::set(1, body)->as<Arr>(); }
     Arr* unset() { return Def::unset()->as<Arr>(); }
     ///@}
 
     /// @name Rebuild
     ///@{
-    Ref reduce(Ref arg) const { return Def::reduce(1, arg); }
-    Arr* stub(Ref type) { return stub_(world(), type)->set(dbg()); }
+    const Def* reduce(const Def* arg) const { return Def::reduce(1, arg); }
+    Arr* stub(const Def* type) { return stub_(world(), type)->set(dbg()); }
     const Def* immutabilize() override;
     ///@}
 
     /// @name Type Checking
     ///@{
-    Ref check(size_t, Ref) override;
-    Ref check() override;
+    const Def* check(size_t, const Def*) override;
+    const Def* check() override;
     ///@}
 
     static constexpr auto Node = Node::Arr;
 
 private:
-    Ref rebuild_(World&, Ref, Defs) const override;
-    Arr* stub_(World&, Ref) override;
+    const Def* rebuild_(World&, const Def*, Defs) const override;
+    Arr* stub_(World&, const Def*) override;
 
     friend class World;
 };
@@ -121,31 +121,31 @@ private:
 public:
     /// @name ops
     ///@{
-    Ref body() const { return op(0); }
-    Ref shape() const;
+    const Def* body() const { return op(0); }
+    const Def* shape() const;
     ///@}
 
     /// @name Setters
     /// @see @ref set_ops "Setting Ops"
     ///@{
     using Setters<Pack>::set;
-    Pack* set(Ref body) { return Def::set(0, body)->as<Pack>(); }
-    Pack* reset(Ref body) { return unset()->set(body); }
+    Pack* set(const Def* body) { return Def::set(0, body)->as<Pack>(); }
+    Pack* reset(const Def* body) { return unset()->set(body); }
     Pack* unset() { return Def::unset()->as<Pack>(); }
     ///@}
 
     /// @name Rebuild
     ///@{
-    Ref reduce(Ref arg) const { return Def::reduce(0, arg); }
-    Pack* stub(Ref type) { return stub_(world(), type)->set(dbg()); }
+    const Def* reduce(const Def* arg) const { return Def::reduce(0, arg); }
+    Pack* stub(const Def* type) { return stub_(world(), type)->set(dbg()); }
     const Def* immutabilize() override;
     ///@}
 
     static constexpr auto Node = Node::Pack;
 
 private:
-    Ref rebuild_(World&, Ref, Defs) const override;
-    Pack* stub_(World&, Ref) override;
+    const Def* rebuild_(World&, const Def*, Defs) const override;
+    Pack* stub_(World&, const Def*) override;
 
     friend class World;
 };
@@ -161,14 +161,14 @@ public:
 
     /// @name ops
     ///@{
-    Ref tuple() const { return op(0); }
-    Ref index() const { return op(1); }
+    const Def* tuple() const { return op(0); }
+    const Def* index() const { return op(1); }
     ///@}
 
     static constexpr auto Node = Node::Extract;
 
 private:
-    Ref rebuild_(World&, Ref, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const override;
 
     friend class World;
 };
@@ -187,40 +187,40 @@ public:
 
     /// @name ops
     ///@{
-    Ref tuple() const { return op(0); }
-    Ref index() const { return op(1); }
-    Ref value() const { return op(2); }
+    const Def* tuple() const { return op(0); }
+    const Def* index() const { return op(1); }
+    const Def* value() const { return op(2); }
     ///@}
 
     static constexpr auto Node = Node::Insert;
 
 private:
-    Ref rebuild_(World&, Ref, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const override;
 
     friend class World;
 };
 
 /// @name Helpers to work with Tulpes/Sigmas/Arrays/Packs
 ///@{
-bool is_unit(Ref);
-std::string tuple2str(Ref);
+bool is_unit(const Def*);
+std::string tuple2str(const Def*);
 
 /// Flattens a sigma/array/pack/tuple.
-Ref flatten(Ref def);
+const Def* flatten(const Def* def);
 /// Same as unflatten, but uses the operands of a flattened Pack / Tuple directly.
-size_t flatten(DefVec& ops, Ref def, bool flatten_sigmas = true);
+size_t flatten(DefVec& ops, const Def* def, bool flatten_sigmas = true);
 
 /// Applies the reverse transformation on a Pack / Tuple, given the original type.
-Ref unflatten(Ref def, Ref type);
+const Def* unflatten(const Def* def, const Def* type);
 /// Same as unflatten, but uses the operands of a flattened Pack / Tuple directly.
-Ref unflatten(Defs ops, Ref type, bool flatten_muts = true);
+const Def* unflatten(Defs ops, const Def* type, bool flatten_muts = true);
 
 DefVec merge(Defs, Defs);
-DefVec merge(Ref def, Defs defs);
-Ref merge_sigma(Ref def, Defs defs);
-Ref merge_tuple(Ref def, Defs defs);
+DefVec merge(const Def* def, Defs defs);
+const Def* merge_sigma(const Def* def, Defs defs);
+const Def* merge_tuple(const Def* def, Defs defs);
 
-Ref tuple_of_types(Ref t);
+const Def* tuple_of_types(const Def* t);
 ///@}
 
 } // namespace mim

--- a/src/mim/ast/ast.cpp
+++ b/src/mim/ast/ast.cpp
@@ -103,9 +103,9 @@ void AST::bootstrap(Sym plugin, std::ostream& h) {
 
         if (auto norm = annex.normalizer) {
             if (auto& subs = annex.subs; !subs.empty()) {
-                tab.print(h, "template<{}>\nRef {}(Ref, Ref, Ref);\n\n", sym.tag, norm);
+                tab.print(h, "template<{}>\nconst Def* {}(const Def*, const Def*, const Def*);\n\n", sym.tag, norm);
             } else {
-                tab.print(h, "Ref {}(Ref, Ref, Ref);\n", norm);
+                tab.print(h, "const Def* {}(const Def*, const Def*, const Def*);\n", norm);
             }
         }
         tab.print(h, "///@}}\n\n");

--- a/src/mim/check.cpp
+++ b/src/mim/check.cpp
@@ -25,7 +25,7 @@ public:
 
 } // namespace
 
-// TODO check local_muts for zonks w/ op
+// TODO check local_muts for Infers w/ op
 const Def* Def::zonk() const { return has_dep(Dep::Infer) ? Zonker(world()).rewrite(this) : this; }
 
 /*

--- a/src/mim/check.cpp
+++ b/src/mim/check.cpp
@@ -14,19 +14,25 @@ public:
     Zonker(World& world)
         : Rewriter(world) {}
 
-    Ref rewrite(Ref old_def) override { return (old_def->has_dep(Dep::Infer)) ? Rewriter::rewrite(old_def) : old_def; }
-    Ref rewrite_mut(Def* mut) override { return mut; }
+    const Def* rewrite(const Def* old) override { return (old->has_dep(Dep::Infer)) ? Rewriter::rewrite(old) : old; }
+
+    const Def* rewrite_mut(Def* mut) override {
+        if (auto infer = mut->isa<Infer>())
+            if (auto op = infer->op()) return rewrite(op);
+        return mut;
+    }
 };
 
 } // namespace
 
-const Def* Def::zonk() const { return has_dep(Dep::Infer) ? *Zonker(world()).rewrite(this) : this; }
+// TODO check local_muts for zonks w/ op
+const Def* Def::zonk() const { return has_dep(Dep::Infer) ? Zonker(world()).rewrite(this) : this; }
 
 /*
  * Infer
  */
 
-const Def* Ref::refer(const Def* def) { return def ? Infer::find(def) : nullptr; }
+const Def* Infer::refer(const Def* def) { return def ? find(def) : nullptr; }
 
 const Def* Infer::find(const Def* def) {
     // find root
@@ -44,7 +50,7 @@ const Def* Infer::find(const Def* def) {
     return res;
 }
 
-Ref Infer::tuplefy() {
+const Def* Infer::tuplefy() {
     if (auto a = type()->isa_lit_arity(); a && !is_set()) {
         auto& w     = world();
         auto n      = *a;
@@ -78,15 +84,15 @@ template<Checker::Mode mode> bool Checker::fail() {
     return false;
 }
 
-Ref Checker::fail() {
+const Def* Checker::fail() {
     if (world().flags().break_on_alpha) fe::breakpoint();
     return {};
 }
 #endif
 
-template<Checker::Mode mode> bool Checker::alpha_(Ref r1, Ref r2) {
-    auto d1 = *r1; // find
-    auto d2 = *r2; // find
+template<Checker::Mode mode> bool Checker::alpha_(const Def* d1, const Def* d2) {
+    d1 = Infer::refer(d1);
+    d2 = Infer::refer(d2);
 
     if (!d1 && !d2) return true;
     if (!d1 || !d2) return fail<mode>();
@@ -140,7 +146,7 @@ template<Checker::Mode mode> bool Checker::alpha_(Ref r1, Ref r2) {
     return alpha_internal<mode>(d1, d2);
 }
 
-template<Checker::Mode mode> bool Checker::alpha_internal(Ref d1, Ref d2) {
+template<Checker::Mode mode> bool Checker::alpha_internal(const Def* d1, const Def* d2) {
     if (!alpha_<mode>(d1->type(), d2->type())) return fail<mode>();
     if (d1->isa<Top>() || d2->isa<Top>()) return mode == Check;
     if (mode == Test && (d1->isa_mut<Infer>() || d2->isa_mut<Infer>())) return fail<mode>();
@@ -180,8 +186,8 @@ template<Checker::Mode mode> bool Checker::alpha_internal(Ref d1, Ref d2) {
     return true;
 }
 
-Ref Checker::assignable_(Ref type, Ref val) {
-    auto val_ty = Ref::refer(val->type());
+const Def* Checker::assignable_(const Def* type, const Def* val) {
+    auto val_ty = Infer::refer(val->type());
     if (type == val_ty) return val;
 
     auto& w = world();
@@ -225,7 +231,7 @@ Ref Checker::assignable_(Ref type, Ref val) {
     return alpha_<Check>(type, val_ty) ? val : fail();
 }
 
-Ref Checker::is_uniform(Defs defs) {
+const Def* Checker::is_uniform(Defs defs) {
     if (defs.empty()) return nullptr;
     auto first = defs.front();
     for (size_t i = 1, e = defs.size(); i != e; ++i)
@@ -237,26 +243,26 @@ Ref Checker::is_uniform(Defs defs) {
  * infer & check
  */
 
-Ref Arr::check(size_t, Ref def) { return def; } // TODO
+const Def* Arr::check(size_t, const Def* def) { return def; } // TODO
 
-Ref Arr::check() {
+const Def* Arr::check() {
     auto t = body()->unfold_type();
     if (!Checker::alpha<Checker::Check>(t, type()))
         error(type()->loc(), "declared sort '{}' of array does not match inferred one '{}'", type(), t);
     return t;
 }
 
-Ref Sigma::infer(World& w, Defs ops) {
+const Def* Sigma::infer(World& w, Defs ops) {
     if (ops.size() == 0) return w.type<1>();
     auto kinds = DefVec(ops.size(), [ops](size_t i) { return ops[i]->unfold_type(); });
     return w.umax<Sort::Kind>(kinds);
 }
 
-Ref Sigma::check(size_t, Ref def) { return def; } // TODO
+const Def* Sigma::check(size_t, const Def* def) { return def; } // TODO
 
-Ref Sigma::check() {
+const Def* Sigma::check() {
     auto t = infer(world(), ops());
-    if (*t != *type()) {
+    if (t != type()) {
         // TODO HACK
         if (Checker::alpha<Checker::Check>(t, type()))
             return t;
@@ -271,7 +277,7 @@ Ref Sigma::check() {
     return t;
 }
 
-Ref Lam::check(size_t i, Ref def) {
+const Def* Lam::check(size_t i, const Def* def) {
     if (i == 0) {
         if (auto filter = Checker::assignable(world().type_bool(), def)) return filter;
         throw Error().error(filter()->loc(), "filter '{}' of lambda is of type '{}' but must be of type 'Bool'",
@@ -287,14 +293,14 @@ Ref Lam::check(size_t i, Ref def) {
     fe::unreachable();
 }
 
-Ref Pi::infer(Ref dom, Ref codom) {
+const Def* Pi::infer(const Def* dom, const Def* codom) {
     auto& w = dom->world();
     return w.umax<Sort::Kind>({dom->unfold_type(), codom->unfold_type()});
 }
 
-Ref Pi::check(size_t, Ref def) { return def; }
+const Def* Pi::check(size_t, const Def* def) { return def; }
 
-Ref Pi::check() {
+const Def* Pi::check() {
     auto t = infer(dom(), codom());
     if (!Checker::alpha<Checker::Check>(t, type()))
         error(type()->loc(), "declared sort '{}' of function type does not match inferred one '{}'", type(), t);
@@ -302,8 +308,8 @@ Ref Pi::check() {
 }
 
 #ifndef DOXYGEN
-template bool Checker::alpha_<Checker::Check>(Ref, Ref);
-template bool Checker::alpha_<Checker::Test>(Ref, Ref);
+template bool Checker::alpha_<Checker::Check>(const Def*, const Def*);
+template bool Checker::alpha_<Checker::Test>(const Def*, const Def*);
 #endif
 
 } // namespace mim

--- a/src/mim/check.cpp
+++ b/src/mim/check.cpp
@@ -41,8 +41,6 @@ const Def* Def::zonk() const {
  * Infer
  */
 
-const Def* Infer::refer(const Def* def) { return def ? find(def) : nullptr; }
-
 const Def* Infer::find(const Def* def) {
     // find root
     auto res = def;
@@ -99,8 +97,8 @@ const Def* Checker::fail() {
 #endif
 
 template<Checker::Mode mode> bool Checker::alpha_(const Def* d1, const Def* d2) {
-    d1 = Infer::refer(d1);
-    d2 = Infer::refer(d2);
+    d1 = d1 ? Infer::find(d1) : nullptr;
+    d2 = d2 ? Infer::find(d2) : nullptr;
 
     if (!d1 && !d2) return true;
     if (!d1 || !d2) return fail<mode>();
@@ -195,7 +193,7 @@ template<Checker::Mode mode> bool Checker::alpha_internal(const Def* d1, const D
 }
 
 const Def* Checker::assignable_(const Def* type, const Def* val) {
-    auto val_ty = Infer::refer(val->type());
+    auto val_ty = Infer::find(val->type());
     if (type == val_ty) return val;
 
     auto& w = world();

--- a/src/mim/def.cpp
+++ b/src/mim/def.cpp
@@ -91,69 +91,69 @@ UMax::UMax(World& world, Defs ops)
  * rebuild
  */
 
-Ref Infer  ::rebuild_(World&,   Ref,   Defs  ) const { fe::unreachable(); }
-Ref Global ::rebuild_(World&,   Ref,   Defs  ) const { fe::unreachable(); }
-Ref Idx    ::rebuild_(World& w, Ref  , Defs  ) const { return w.type_idx(); }
-Ref Nat    ::rebuild_(World& w, Ref  , Defs  ) const { return w.type_nat(); }
-Ref Univ   ::rebuild_(World& w, Ref  , Defs  ) const { return w.univ(); }
-Ref Ac     ::rebuild_(World& w, Ref t, Defs o) const { return w.ac(t, o); }
-Ref App    ::rebuild_(World& w, Ref  , Defs o) const { return w.app(o[0], o[1]); }
-Ref Arr    ::rebuild_(World& w, Ref  , Defs o) const { return w.arr(o[0], o[1]); }
-Ref Extract::rebuild_(World& w, Ref  , Defs o) const { return w.extract(o[0], o[1]); }
-Ref Insert ::rebuild_(World& w, Ref  , Defs o) const { return w.insert(o[0], o[1], o[2]); }
-Ref Lam    ::rebuild_(World& w, Ref t, Defs o) const { return w.lam(t->as<Pi>(), o[0], o[1]); }
-Ref Lit    ::rebuild_(World& w, Ref t, Defs  ) const { return w.lit(t, get()); }
-Ref Pack   ::rebuild_(World& w, Ref t, Defs o) const { return w.pack(t->arity(), o[0]); }
-Ref Pi     ::rebuild_(World& w, Ref  , Defs o) const { return w.pi(o[0], o[1], is_implicit()); }
-Ref Pick   ::rebuild_(World& w, Ref t, Defs o) const { return w.pick(t, o[0]); }
-Ref Proxy  ::rebuild_(World& w, Ref t, Defs o) const { return w.proxy(t, o, pass(), tag()); }
-Ref Sigma  ::rebuild_(World& w, Ref  , Defs o) const { return w.sigma(o); }
-Ref Uniq   ::rebuild_(World& w, Ref  , Defs o) const { return w.uniq(o[0]); }
-Ref Type   ::rebuild_(World& w, Ref  , Defs o) const { return w.type(o[0]); }
-Ref Test   ::rebuild_(World& w, Ref  , Defs o) const { return w.test(o[0], o[1], o[2], o[3]); }
-Ref Tuple  ::rebuild_(World& w, Ref t, Defs o) const { return w.tuple(t, o); }
-Ref UInc   ::rebuild_(World& w, Ref  , Defs o) const { return w.uinc(o[0], offset()); }
-Ref UMax   ::rebuild_(World& w, Ref  , Defs o) const { return w.umax(o); }
-Ref Var    ::rebuild_(World& w, Ref t, Defs o) const { return w.var(t, o[0]->as_mut()); }
-Ref Vel    ::rebuild_(World& w, Ref t, Defs o) const { return w.vel(t, o[0])->set(dbg()); }
+const Def* Infer  ::rebuild_(World&,   const Def*,   Defs  ) const { fe::unreachable(); }
+const Def* Global ::rebuild_(World&,   const Def*,   Defs  ) const { fe::unreachable(); }
+const Def* Idx    ::rebuild_(World& w, const Def*  , Defs  ) const { return w.type_idx(); }
+const Def* Nat    ::rebuild_(World& w, const Def*  , Defs  ) const { return w.type_nat(); }
+const Def* Univ   ::rebuild_(World& w, const Def*  , Defs  ) const { return w.univ(); }
+const Def* Ac     ::rebuild_(World& w, const Def* t, Defs o) const { return w.ac(t, o); }
+const Def* App    ::rebuild_(World& w, const Def*  , Defs o) const { return w.app(o[0], o[1]); }
+const Def* Arr    ::rebuild_(World& w, const Def*  , Defs o) const { return w.arr(o[0], o[1]); }
+const Def* Extract::rebuild_(World& w, const Def*  , Defs o) const { return w.extract(o[0], o[1]); }
+const Def* Insert ::rebuild_(World& w, const Def*  , Defs o) const { return w.insert(o[0], o[1], o[2]); }
+const Def* Lam    ::rebuild_(World& w, const Def* t, Defs o) const { return w.lam(t->as<Pi>(), o[0], o[1]); }
+const Def* Lit    ::rebuild_(World& w, const Def* t, Defs  ) const { return w.lit(t, get()); }
+const Def* Pack   ::rebuild_(World& w, const Def* t, Defs o) const { return w.pack(t->arity(), o[0]); }
+const Def* Pi     ::rebuild_(World& w, const Def*  , Defs o) const { return w.pi(o[0], o[1], is_implicit()); }
+const Def* Pick   ::rebuild_(World& w, const Def* t, Defs o) const { return w.pick(t, o[0]); }
+const Def* Proxy  ::rebuild_(World& w, const Def* t, Defs o) const { return w.proxy(t, o, pass(), tag()); }
+const Def* Sigma  ::rebuild_(World& w, const Def*  , Defs o) const { return w.sigma(o); }
+const Def* Uniq   ::rebuild_(World& w, const Def*  , Defs o) const { return w.uniq(o[0]); }
+const Def* Type   ::rebuild_(World& w, const Def*  , Defs o) const { return w.type(o[0]); }
+const Def* Test   ::rebuild_(World& w, const Def*  , Defs o) const { return w.test(o[0], o[1], o[2], o[3]); }
+const Def* Tuple  ::rebuild_(World& w, const Def* t, Defs o) const { return w.tuple(t, o); }
+const Def* UInc   ::rebuild_(World& w, const Def*  , Defs o) const { return w.uinc(o[0], offset()); }
+const Def* UMax   ::rebuild_(World& w, const Def*  , Defs o) const { return w.umax(o); }
+const Def* Var    ::rebuild_(World& w, const Def* t, Defs o) const { return w.var(t, o[0]->as_mut()); }
+const Def* Vel    ::rebuild_(World& w, const Def* t, Defs o) const { return w.vel(t, o[0])->set(dbg()); }
 
-Ref Axiom    ::rebuild_(World& w, Ref t, Defs ) const {
+const Def* Axiom    ::rebuild_(World& w, const Def* t, Defs ) const {
     if (&w != &world()) return w.axiom(normalizer(), curry(), trip(), t, plugin(), tag(), sub())->set(dbg());
     assert(Checker::alpha<Checker::Check>(t, type()));
     return this;
 }
 
-template<bool up> Ref TExt  <up>::rebuild_(World& w, Ref t, Defs  ) const { return w.ext  <up>(t)->set(dbg()); }
-template<bool up> Ref TBound<up>::rebuild_(World& w, Ref  , Defs o) const { return w.bound<up>(o)->set(dbg()); }
+template<bool up> const Def* TExt  <up>::rebuild_(World& w, const Def* t, Defs  ) const { return w.ext  <up>(t)->set(dbg()); }
+template<bool up> const Def* TBound<up>::rebuild_(World& w, const Def*  , Defs o) const { return w.bound<up>(o)->set(dbg()); }
 
 /*
  * stub
  */
 
-Arr*    Arr   ::stub_(World& w, Ref t) { return w.mut_arr  (t); }
-Global* Global::stub_(World& w, Ref t) { return w.global   (t, is_mutable()); }
-Infer*  Infer ::stub_(World& w, Ref t) { return w.mut_infer(t); }
-Lam*    Lam   ::stub_(World& w, Ref t) { return w.mut_lam  (t->as<Pi>()); }
-Pack*   Pack  ::stub_(World& w, Ref t) { return w.mut_pack (t); }
-Pi*     Pi    ::stub_(World& w, Ref t) { return w.mut_pi   (t, is_implicit()); }
-Sigma*  Sigma ::stub_(World& w, Ref t) { return w.mut_sigma(t, num_ops()); }
+Arr*    Arr   ::stub_(World& w, const Def* t) { return w.mut_arr  (t); }
+Global* Global::stub_(World& w, const Def* t) { return w.global   (t, is_mutable()); }
+Infer*  Infer ::stub_(World& w, const Def* t) { return w.mut_infer(t); }
+Lam*    Lam   ::stub_(World& w, const Def* t) { return w.mut_lam  (t->as<Pi>()); }
+Pack*   Pack  ::stub_(World& w, const Def* t) { return w.mut_pack (t); }
+Pi*     Pi    ::stub_(World& w, const Def* t) { return w.mut_pi   (t, is_implicit()); }
+Sigma*  Sigma ::stub_(World& w, const Def* t) { return w.mut_sigma(t, num_ops()); }
 
-template<bool up> TBound<up>* TBound<up>::stub_(World& w, Ref t) { return w.mut_bound<up>(t, num_ops()); }
-template<bool up> TExt  <up>* TExt  <up>::stub_(World&  , Ref  ) { fe::unreachable(); }
+template<bool up> TBound<up>* TBound<up>::stub_(World& w, const Def* t) { return w.mut_bound<up>(t, num_ops()); }
+template<bool up> TExt  <up>* TExt  <up>::stub_(World&  , const Def*  ) { fe::unreachable(); }
 
 /*
  * instantiate templates
  */
 
 #ifndef DOXYGEN
-template Ref            TExt<false>  ::rebuild_(World&, Ref, Defs) const;
-template Ref            TExt<true >  ::rebuild_(World&, Ref, Defs) const;
-template Ref            TBound<false>::rebuild_(World&, Ref, Defs) const;
-template Ref            TBound<true >::rebuild_(World&, Ref, Defs) const;
-template TBound<false>* TBound<false>::stub_(World&, Ref);
-template TBound<true >* TBound<true >::stub_(World&, Ref);
-template TExt<false>*   TExt<false>  ::stub_(World&, Ref);
-template TExt<true >*   TExt<true >  ::stub_(World&, Ref);
+template const Def*            TExt<false>  ::rebuild_(World&, const Def*, Defs) const;
+template const Def*            TExt<true >  ::rebuild_(World&, const Def*, Defs) const;
+template const Def*            TBound<false>::rebuild_(World&, const Def*, Defs) const;
+template const Def*            TBound<true >::rebuild_(World&, const Def*, Defs) const;
+template TBound<false>* TBound<false>::stub_(World&, const Def*);
+template TBound<true >* TBound<true >::stub_(World&, const Def*);
+template TExt<false>*   TExt<false>  ::stub_(World&, const Def*);
+template TExt<true >*   TExt<true >  ::stub_(World&, const Def*);
 #endif
 
 // clang-format on
@@ -178,7 +178,7 @@ const Pi* Pi::immutabilize() {
 }
 
 const Def* Sigma::immutabilize() {
-    if (is_immutabilizable()) return static_cast<const Sigma*>(*world().sigma(ops()));
+    if (is_immutabilizable()) return static_cast<const Sigma*>(world().sigma(ops()));
     return nullptr;
 }
 
@@ -206,12 +206,12 @@ const Def* Pack::immutabilize() {
  * reduce
  */
 
-DefVec Def::reduce(Ref arg) const {
+DefVec Def::reduce(const Def* arg) const {
     if (auto mut = isa_mut()) return mut->reduce(arg);
     return DefVec(ops().begin(), ops().end());
 }
 
-DefVec Def::reduce(Ref arg) {
+DefVec Def::reduce(const Def* arg) {
     if (auto var = has_var()) {
         auto& cache = world().move_.cache;
         if (auto i = cache.find({this, arg}); i != cache.end()) return i->second;
@@ -225,12 +225,12 @@ DefVec Def::reduce(Ref arg) {
     return DefVec(ops().begin(), ops().end());
 }
 
-Ref Def::reduce(size_t i, Ref arg) const {
+const Def* Def::reduce(size_t i, const Def* arg) const {
     if (auto mut = isa_mut(); mut && has_var()) return mut->reduce(arg)[i];
     return op(i);
 }
 
-Ref Def::refine(size_t i, Ref new_op) const {
+const Def* Def::refine(size_t i, const Def* new_op) const {
     DefVec new_ops(ops().begin(), ops().end());
     new_ops[i] = new_op;
     return rebuild(type(), new_ops);
@@ -245,7 +245,7 @@ Def* Def::  set(Defs ops) { assert(ops.size() == num_ops()); for (size_t i = 0, 
 Def* Def::reset(Defs ops) { assert(ops.size() == num_ops()); for (size_t i = 0, e = num_ops(); i != e; ++i) reset(i, ops[i]); return this; }
 // clang-format on
 
-Def* Def::set(size_t i, Ref def) {
+Def* Def::set(size_t i, const Def* def) {
     invalidate();
     def = check(i, def);
     assert(def && !op(i) && curr_op_ == i);
@@ -403,11 +403,11 @@ Sym Def::sym(std::string s) const { return world().sym(std::move(s)); }
 World& Def::world() const noexcept {
     for (auto def = this;; def = def->type()) {
         if (def->isa<Univ>()) return *def->world_;
-        if (auto type = def->isa<Type>()) return *type->level().def()->type().def()->as<Univ>()->world_;
+        if (auto type = def->isa<Type>()) return *type->level()->type()->as<Univ>()->world_;
     }
 }
 
-Ref Def::unfold_type() const {
+const Def* Def::unfold_type() const {
     if (!type_) {
         auto& w = world();
         if (auto t = isa<Type>()) return w.type(w.uinc(t->level()));
@@ -441,7 +441,7 @@ const Def* Def::debug_suffix(std::string suffix) const { return dbg_.set(world()
 
 // clang-format off
 
-Ref Def::var() {
+const Def* Def::var() {
     if (var_) return var_;
     auto& w = world();
 
@@ -468,7 +468,7 @@ bool Def::is_term() const {
     return false;
 }
 
-Ref Def::arity() const {
+const Def* Def::arity() const {
     if (auto sigma  = isa<Sigma>()) return world().lit_nat(sigma->num_ops());
     if (auto arr    = isa<Arr  >()) return arr->shape();
     if (auto t = type())            return t->arity();
@@ -505,7 +505,7 @@ nat_t Def::num_tprojs() const {
     return 1;
 }
 
-Ref Def::proj(nat_t a, nat_t i) const {
+const Def* Def::proj(nat_t a, nat_t i) const {
     World& w = world();
 
     if (auto arr = isa<Arr>()) {
@@ -532,7 +532,7 @@ Ref Def::proj(nat_t a, nat_t i) const {
  * Idx
  */
 
-Ref Idx::isa(Ref def) {
+const Def* Idx::isa(const Def* def) {
     if (auto app = def->isa<App>()) {
         if (app->callee()->isa<Idx>()) return app->arg();
     }
@@ -540,13 +540,13 @@ Ref Idx::isa(Ref def) {
     return nullptr;
 }
 
-std::optional<nat_t> Idx::isa_lit(Ref def) {
+std::optional<nat_t> Idx::isa_lit(const Def* def) {
     if (auto size = Idx::isa(def))
         if (auto l = Lit::isa(size)) return l;
     return {};
 }
 
-std::optional<nat_t> Idx::size2bitwidth(Ref size) {
+std::optional<nat_t> Idx::size2bitwidth(const Def* size) {
     if (size->isa<Top>()) return 64;
     if (auto s = Lit::isa(size)) return size2bitwidth(*s);
     return {};
@@ -557,6 +557,6 @@ std::optional<nat_t> Idx::size2bitwidth(Ref size) {
  */
 
 const App* Global::type() const { return Def::type()->as<App>(); }
-Ref Global::alloced_type() const { return type()->arg(0); }
+const Def* Global::alloced_type() const { return type()->arg(0); }
 
 } // namespace mim

--- a/src/mim/dot.cpp
+++ b/src/mim/dot.cpp
@@ -11,7 +11,7 @@
 using namespace std::string_literals;
 
 // Do not zonk here!
-// We want to see all Refs in the DOT graph.
+// We want to see all const Def*s in the DOT graph.
 
 namespace mim {
 
@@ -66,7 +66,7 @@ public:
         if (!def->is_set()) return;
 
         for (size_t i = 0, e = def->num_ops(); i != e; ++i) {
-            auto op = def->op(i).def();
+            auto op = def->op(i);
             recurse(op, max - 1);
             tab_.print(os_, "_{} -> _{}[taillabel=\"{}\",", def->gid(), op->gid(), i);
             if (op->isa<Lit>() || op->isa<Axiom>() || def->isa<Var>() || def->isa<Nat>() || def->isa<Idx>())
@@ -75,7 +75,7 @@ public:
                 print(os_, "];\n");
         }
 
-        if (auto t = def->type().def(); t && types_) {
+        if (auto t = def->type(); t && types_) {
             recurse(t, max - 1);
             tab_.println(os_, "_{} -> _{}[color=\"#00000000\",constraint=false,style=dashed];", def->gid(), t->gid());
         }
@@ -97,7 +97,7 @@ public:
     std::ostream& tooltip(const Def* def) {
         static constexpr auto NL = "&#13;&#10;";
         auto loc                 = escape(def->loc());
-        auto type                = escape(def->type().def());
+        auto type                = escape(def->type());
         escape(loc);
         print(os_, "tooltip=\"");
         print(os_, "<b>expr:</b> {}{}", def, NL);

--- a/src/mim/dump.cpp
+++ b/src/mim/dump.cpp
@@ -414,8 +414,6 @@ void Dumper::recurse(const Def* def, bool first /*= false*/) {
  * Def
  */
 
-std::ostream& operator<<(std::ostream& os, Ref ref) { return os << *ref; }
-
 /// This will stream @p def as an operand.
 /// This is usually `id(def)` unless it can be displayed Inline.
 std::ostream& operator<<(std::ostream& os, const Def* def) {

--- a/src/mim/lam.cpp
+++ b/src/mim/lam.cpp
@@ -26,14 +26,14 @@ Pi* Pi::set_dom(Defs doms) { return Def::set(0, world().sigma(doms))->as<Pi>(); 
  */
 
 Lam* Lam::set_filter(Filter filter) { return Def::set(0, world().filter(filter))->as<Lam>(); }
-Lam* Lam::app(Filter f, Ref callee, Ref arg) { return set_filter(f)->set_body(world().app(callee, arg)); }
-Lam* Lam::app(Filter filter, Ref callee, Defs args) { return app(filter, callee, world().tuple(args)); }
+Lam* Lam::app(Filter f, const Def* callee, const Def* arg) { return set_filter(f)->set_body(world().app(callee, arg)); }
+Lam* Lam::app(Filter filter, const Def* callee, Defs args) { return app(filter, callee, world().tuple(args)); }
 
-Lam* Lam::branch(Filter filter, Ref cond, Ref t, Ref f, Ref mem) {
+Lam* Lam::branch(Filter filter, const Def* cond, const Def* t, const Def* f, const Def* mem) {
     return app(filter, world().select(cond, t, f), mem ? mem : world().tuple());
 }
 
-Lam* Lam::test(Filter filter, Ref value, Ref index, Ref match, Ref clash, Ref mem) {
+Lam* Lam::test(Filter filter, const Def* value, const Def* index, const Def* match, const Def* clash, const Def* mem) {
     return app(filter, world().test(value, index, match, clash), mem);
 }
 
@@ -41,7 +41,7 @@ Lam* Lam::test(Filter filter, Ref value, Ref index, Ref match, Ref clash, Ref me
  * Helpers
  */
 
-std::deque<const App*> decurry(Ref def) {
+std::deque<const App*> decurry(const Def* def) {
     std::deque<const App*> apps;
     while (auto app = def->isa<App>()) {
         apps.emplace_front(app);
@@ -50,7 +50,7 @@ std::deque<const App*> decurry(Ref def) {
     return apps;
 }
 
-Ref compose_cn(Ref f, Ref g) {
+const Def* compose_cn(const Def* f, const Def* g) {
     auto& world = f->world();
     world.DLOG("compose f (B->C): {} : {}", f, f->type());
     world.DLOG("compose g (A->B): {} : {}", g, g->type());
@@ -83,7 +83,7 @@ Ref compose_cn(Ref f, Ref g) {
     return h;
 }
 
-std::pair<Ref, DefVec> collect_args(Ref def) {
+std::pair<const Def*, DefVec> collect_args(const Def* def) {
     DefVec args;
     if (auto app = def->isa<App>()) {
         auto callee               = app->callee();

--- a/src/mim/pass/beta_red.cpp
+++ b/src/mim/pass/beta_red.cpp
@@ -4,7 +4,7 @@
 
 namespace mim {
 
-Ref BetaRed::rewrite(Ref def) {
+const Def* BetaRed::rewrite(const Def* def) {
     if (auto [app, lam] = isa_apped_mut_lam(def); isa_workable(lam) && !keep_.contains(lam)) {
         if (auto [_, ins] = data().emplace(lam); ins) {
             world().DLOG("beta-reduction {}", lam);
@@ -27,7 +27,7 @@ undo_t BetaRed::analyze(const Proxy* proxy) {
     return No_Undo;
 }
 
-undo_t BetaRed::analyze(Ref def) {
+undo_t BetaRed::analyze(const Def* def) {
     auto undo = No_Undo;
     for (auto op : def->ops()) {
         if (auto lam = isa_workable(op->isa_mut<Lam>()); lam && keep_.emplace(lam).second) {

--- a/src/mim/pass/eta_exp.cpp
+++ b/src/mim/pass/eta_exp.cpp
@@ -17,8 +17,8 @@ Lam* EtaExp::new2old(Lam* new_lam) {
     return new_lam;
 }
 
-Ref EtaExp::rewrite(Ref def) {
-    if (std::ranges::none_of(def->ops(), [](Ref def) { return def->isa<Lam>(); })) return def;
+const Def* EtaExp::rewrite(const Def* def) {
+    if (std::ranges::none_of(def->ops(), [](const Def* def) { return def->isa<Lam>(); })) return def;
     if (auto n = lookup(old2new(), def)) return n;
 
     auto [i, ins] = def2new_ops_.emplace(def, DefVec{});
@@ -57,7 +57,7 @@ undo_t EtaExp::analyze(const Proxy* proxy) {
     return No_Undo;
 }
 
-undo_t EtaExp::analyze(Ref def) {
+undo_t EtaExp::analyze(const Def* def) {
     auto undo = No_Undo;
     for (size_t i = 0, e = def->num_ops(); i != e; ++i) {
         if (auto lam = def->op(i)->isa_mut<Lam>(); lam && lam->is_set()) {

--- a/src/mim/pass/eta_red.cpp
+++ b/src/mim/pass/eta_red.cpp
@@ -3,7 +3,7 @@
 namespace mim {
 
 namespace {
-bool is_var(Ref def) {
+bool is_var(const Def* def) {
     if (def->isa<Var>()) return true;
     if (auto extract = def->isa<Extract>()) return extract->tuple()->isa<Var>();
     return false;
@@ -18,7 +18,7 @@ const App* eta_rule(Lam* lam) {
 }
 } // namespace
 
-Ref EtaRed::rewrite(Ref def) {
+const Def* EtaRed::rewrite(const Def* def) {
     for (size_t i = 0, e = def->num_ops(); i != e; ++i) {
         // TODO (ClosureConv): Factor this out
         if (auto lam = def->op(i)->isa_mut<Lam>(); (!callee_only_ || isa_callee(def, i)) && lam && lam->is_set()) {

--- a/src/mim/pass/lam_spec.cpp
+++ b/src/mim/pass/lam_spec.cpp
@@ -6,7 +6,7 @@
 
 namespace mim {
 
-Ref LamSpec::rewrite(Ref def) {
+const Def* LamSpec::rewrite(const Def* def) {
     if (auto i = old2new_.find(def); i != old2new_.end()) return i->second;
 
     auto [app, old_lam] = isa_apped_mut_lam(def);

--- a/src/mim/pass/pass.cpp
+++ b/src/mim/pass/pass.cpp
@@ -87,7 +87,7 @@ void PassMan::run() {
     Phase::run<Cleanup>(world());
 }
 
-Ref PassMan::rewrite(Ref old_def) {
+const Def* PassMan::rewrite(const Def* old_def) {
     if (!old_def->has_dep()) return old_def;
 
     if (auto mut = old_def->isa_mut()) {
@@ -126,7 +126,7 @@ Ref PassMan::rewrite(Ref old_def) {
     return map(old_def, new_def);
 }
 
-undo_t PassMan::analyze(Ref def) {
+undo_t PassMan::analyze(const Def* def) {
     undo_t undo = No_Undo;
 
     if (!def->has_dep() || analyzed(def)) {

--- a/src/mim/pass/tail_rec_elim.cpp
+++ b/src/mim/pass/tail_rec_elim.cpp
@@ -5,7 +5,7 @@
 
 namespace mim {
 
-Ref TailRecElim::rewrite(Ref def) {
+const Def* TailRecElim::rewrite(const Def* def) {
     if (auto [app, old] = isa_apped_mut_lam(def); old) {
         if (auto i = old2rec_loop_.find(old); i != old2rec_loop_.end()) {
             auto [rec, loop] = i->second;
@@ -20,7 +20,7 @@ Ref TailRecElim::rewrite(Ref def) {
     return def;
 }
 
-undo_t TailRecElim::analyze(Ref def) {
+undo_t TailRecElim::analyze(const Def* def) {
     if (auto [app, old] = isa_apped_mut_lam(def); old) {
         if (auto ret_var = old->ret_var(); ret_var && app->args().back() == ret_var) {
             if (auto [i, ins] = old2rec_loop_.emplace(old, std::pair<Lam*, Lam*>(nullptr, nullptr)); ins) {

--- a/src/mim/plug/affine/pass/lower_for.cpp
+++ b/src/mim/plug/affine/pass/lower_for.cpp
@@ -11,7 +11,7 @@ namespace mim::plug::affine {
 
 namespace {
 
-const Def* merge_s(World& w, Ref elem, Ref sigma, Ref mem) {
+const Def* merge_s(World& w, const Def* elem, const Def* sigma, const Def* mem) {
     if (mem) {
         auto elems = sigma->projs();
         return merge_sigma(elem, elems);
@@ -19,7 +19,7 @@ const Def* merge_s(World& w, Ref elem, Ref sigma, Ref mem) {
     return w.sigma({elem, sigma});
 }
 
-const Def* merge_t(World& w, Ref elem, Ref tuple, Ref mem) {
+const Def* merge_t(World& w, const Def* elem, const Def* tuple, const Def* mem) {
     if (mem) {
         auto elems = tuple->projs();
         return merge_tuple(elem, elems);
@@ -29,7 +29,7 @@ const Def* merge_t(World& w, Ref elem, Ref tuple, Ref mem) {
 
 } // namespace
 
-Ref LowerFor::rewrite(Ref def) {
+const Def* LowerFor::rewrite(const Def* def) {
     if (auto i = rewritten_.find(def); i != rewritten_.end()) return i->second;
 
     if (auto for_ax = match<affine::For>(def)) {

--- a/src/mim/plug/autodiff/auxiliary/autodiff_rewrite_toplevel.cpp
+++ b/src/mim/plug/autodiff/auxiliary/autodiff_rewrite_toplevel.cpp
@@ -4,7 +4,7 @@
 namespace mim::plug::autodiff {
 
 /// Additionally to the derivation, the pullback is registered and the maps are initialized.
-Ref AutoDiffEval::derive_(Ref def) {
+const Def* AutoDiffEval::derive_(const Def* def) {
     auto lam = def->as_mut<Lam>(); // TODO check if mutable
     world().DLOG("Derive lambda: {}", def);
     auto deriv_ty = autodiff_type_fun_pi(lam->type());
@@ -18,7 +18,7 @@ Ref AutoDiffEval::derive_(Ref def) {
 
     auto [arg_ty, ret_pi] = lam->type()->doms<2>();
     auto deriv_all_args   = deriv->var();
-    Ref deriv_arg         = deriv->var(0_s)->set("arg");
+    const Def* deriv_arg  = deriv->var(0_s)->set("arg");
 
     // We generate the shadow pullbacks dynamically to save work and avoid code duplication.
     // Only the toplevel pullback for arguments and return continuation is special cased.

--- a/src/mim/plug/autodiff/normalizers.cpp
+++ b/src/mim/plug/autodiff/normalizers.cpp
@@ -8,24 +8,24 @@ namespace mim::plug::autodiff {
 
 /// Currently this normalizer does nothin.
 /// TODO: Maybe we want to handle trivial lookup replacements here.
-Ref normalize_ad(Ref, Ref, Ref) { return {}; }
+const Def* normalize_ad(const Def*, const Def*, const Def*) { return {}; }
 
-Ref normalize_AD(Ref, Ref, Ref arg) {
+const Def* normalize_AD(const Def*, const Def*, const Def* arg) {
     auto ad_ty = autodiff_type_fun(arg);
     if (ad_ty) return ad_ty;
     return {};
 }
 
-Ref normalize_Tangent(Ref, Ref, Ref arg) { return tangent_type_fun(arg); }
+const Def* normalize_Tangent(const Def*, const Def*, const Def* arg) { return tangent_type_fun(arg); }
 
 /// Currently this normalizer does nothing.
 /// We usually want to keep zeros as long as possible to avoid unnecessary allocations.
 /// A high-level addition with zero can be shortened directly.
-Ref normalize_zero(Ref, Ref, Ref) { return {}; }
+const Def* normalize_zero(const Def*, const Def*, const Def*) { return {}; }
 
 /// Currently resolved the full addition.
 /// There is no benefit in keeping additions around longer than necessary.
-Ref normalize_add(Ref type, Ref callee, Ref arg) {
+const Def* normalize_add(const Def* type, const Def* callee, const Def* arg) {
     auto& world = type->world();
 
     // TODO: add tuple -> tuple of adds
@@ -78,7 +78,7 @@ Ref normalize_add(Ref type, Ref callee, Ref arg) {
     return {};
 }
 
-Ref normalize_sum(Ref type, Ref callee, Ref arg) {
+const Def* normalize_sum(const Def* type, const Def* callee, const Def* arg) {
     auto& world = type->world();
 
     auto [count, T] = callee->as<App>()->args<2>();

--- a/src/mim/plug/autodiff/pass/autodiff_eval.cpp
+++ b/src/mim/plug/autodiff/pass/autodiff_eval.cpp
@@ -12,19 +12,19 @@
 namespace mim::plug::autodiff {
 
 // TODO: maybe use template (https://codereview.stackexchange.com/questions/141961/memoization-via-template) to memoize
-Ref AutoDiffEval::augment(Ref def, Lam* f, Lam* f_diff) {
+const Def* AutoDiffEval::augment(const Def* def, Lam* f, Lam* f_diff) {
     if (auto i = augmented.find(def); i != augmented.end()) return i->second;
     augmented[def] = augment_(def, f, f_diff);
     return augmented[def];
 }
 
-Ref AutoDiffEval::derive(Ref def) {
+const Def* AutoDiffEval::derive(const Def* def) {
     if (auto i = derived.find(def); i != derived.end()) return i->second;
     derived[def] = derive_(def);
     return derived[def];
 }
 
-Ref AutoDiffEval::rewrite(Ref def) {
+const Def* AutoDiffEval::rewrite(const Def* def) {
     if (auto ad_app = match<ad>(def); ad_app) {
         // callee = autodiff T
         // arg = function of type T

--- a/src/mim/plug/autodiff/pass/autodiff_zero.cpp
+++ b/src/mim/plug/autodiff/pass/autodiff_zero.cpp
@@ -11,7 +11,7 @@
 
 namespace mim::plug::autodiff {
 
-Ref AutoDiffZero::rewrite(Ref def) {
+const Def* AutoDiffZero::rewrite(const Def* def) {
     if (auto zero_app = match<zero>(def); zero_app) {
         // callee = zero
         // arg = type T

--- a/src/mim/plug/autodiff/pass/autodiff_zero_cleanup.cpp
+++ b/src/mim/plug/autodiff/pass/autodiff_zero_cleanup.cpp
@@ -11,7 +11,7 @@
 
 namespace mim::plug::autodiff {
 
-Ref AutoDiffZeroCleanup::rewrite(Ref def) {
+const Def* AutoDiffZeroCleanup::rewrite(const Def* def) {
     // Ideally this code segment is never reached.
     // (all zeros are resolved before)
     if (auto zero_app = match<zero>(def); zero_app) {

--- a/src/mim/plug/autodiff/rules.rs
+++ b/src/mim/plug/autodiff/rules.rs
@@ -1,4 +1,4 @@
-// Reference: https://www.overleaf.com/read/gdpfxvzqpfjf
+// const Def*erence: https://www.overleaf.com/read/gdpfxvzqpfjf
 
 
 // easy readable:

--- a/src/mim/plug/clos/normalizers.cpp
+++ b/src/mim/plug/clos/normalizers.cpp
@@ -2,7 +2,9 @@
 
 namespace mim::plug::clos {
 
-template<attr o> Ref normalize_clos(Ref, Ref, Ref arg) { return o == attr::bottom ? arg : Ref{}; }
+template<attr o> const Def* normalize_clos(const Def*, const Def*, const Def* arg) {
+    return o == attr::bottom ? arg : nullptr;
+}
 
 MIM_clos_NORMALIZER_IMPL
 

--- a/src/mim/plug/clos/pass/branch_clos_elim.cpp
+++ b/src/mim/plug/clos/pass/branch_clos_elim.cpp
@@ -6,7 +6,7 @@ namespace mim::plug::clos {
 
 namespace {
 
-std::tuple<std::vector<ClosLit>, Ref> isa_branch(Ref callee) {
+std::tuple<std::vector<ClosLit>, const Def*> isa_branch(const Def* callee) {
     if (auto closure_proj = callee->isa<Extract>()) {
         auto inner_proj = closure_proj->tuple()->isa<Extract>();
         if (inner_proj && inner_proj->tuple()->isa<Tuple>() && isa_clos_type(inner_proj->type())) {
@@ -24,7 +24,7 @@ std::tuple<std::vector<ClosLit>, Ref> isa_branch(Ref callee) {
 
 } // namespace
 
-Ref BranchClosElim::rewrite(Ref def) {
+const Def* BranchClosElim::rewrite(const Def* def) {
     auto& w  = world();
     auto app = def->isa<App>();
     if (!app || !Pi::isa_cn(app->callee_type())) return def;

--- a/src/mim/plug/clos/phase/lower_typed_clos.cpp
+++ b/src/mim/plug/clos/phase/lower_typed_clos.cpp
@@ -8,7 +8,7 @@ namespace mim::plug::clos {
 
 namespace {
 const Def* insert_ret(const Def* def, const Def* ret) {
-    auto new_ops = DefVec(def->num_projs() + 1, [&](auto i) { return (i == def->num_projs()) ? ret : *def->proj(i); });
+    auto new_ops = DefVec(def->num_projs() + 1, [&](auto i) { return (i == def->num_projs()) ? ret : def->proj(i); });
     auto& w      = def->world();
     return def->is_term() ? w.tuple(new_ops) : w.sigma(new_ops);
 }
@@ -69,7 +69,7 @@ Lam* LowerTypedClos::make_stub(Lam* lam, enum Mode mode, bool adjust_bb_type) {
         env = w.call<core::bitcast>(lam->dom(Clos_Env_Param), env)->set("unboxed_env");
     }
     auto new_args = w.tuple(DefVec(lam->num_doms(), [&](auto i) {
-        return (i == Clos_Env_Param) ? env : (lam->var(i) == mem::mem_var(lam)) ? lcm : *new_lam->var(i);
+        return (i == Clos_Env_Param) ? env : (lam->var(i) == mem::mem_var(lam)) ? lcm : new_lam->var(i);
     }));
     assert(new_args->num_projs() == lam->num_doms());
     assert(lam->num_doms() <= new_lam->num_doms());

--- a/src/mim/plug/compile/normalizers.cpp
+++ b/src/mim/plug/compile/normalizers.cpp
@@ -4,7 +4,7 @@
 namespace mim::plug::compile {
 
 // `pass_phase (pass_list pass1 ... passn)` -> `passes_to_phase n (pass1, ..., passn)`
-Ref normalize_pass_phase(Ref type, Ref, Ref arg) {
+const Def* normalize_pass_phase(const Def* type, const Def*, const Def* arg) {
     auto& world = type->world();
 
     auto [ax, _] = collect_args(arg);
@@ -26,7 +26,7 @@ Ref normalize_pass_phase(Ref type, Ref, Ref arg) {
 }
 
 /// `combined_phase (phase_list phase1 ... phasen)` -> `phases_to_phase n (phase1, ..., phasen)`
-Ref normalize_combined_phase(Ref type, Ref, Ref arg) {
+const Def* normalize_combined_phase(const Def* type, const Def*, const Def* arg) {
     auto& world = type->world();
 
     auto [ax, phase_list_defs] = collect_args(arg);
@@ -37,11 +37,13 @@ Ref normalize_combined_phase(Ref type, Ref, Ref arg) {
 }
 
 /// `single_pass_phase pass` -> `passes_to_phase 1 pass`
-Ref normalize_single_pass_phase(Ref type, Ref, Ref arg) { return type->world().call<passes_to_phase>(1, arg); }
+const Def* normalize_single_pass_phase(const Def* type, const Def*, const Def* arg) {
+    return type->world().call<passes_to_phase>(1, arg);
+}
 
 /// `combine_pass_list K (pass_list pass11 ... pass1N) ... (pass_list passK1 ... passKM) = pass_list pass11 ... p1N ...
 /// passK1 ... passKM`
-Ref normalize_combine_pass_list(Ref type, Ref, Ref arg) {
+const Def* normalize_combine_pass_list(const Def* type, const Def*, const Def* arg) {
     auto& world     = type->world();
     auto pass_lists = arg->projs();
     DefVec passes;
@@ -51,7 +53,7 @@ Ref normalize_combine_pass_list(Ref type, Ref, Ref arg) {
         assert(ax->flags() == flags_t(Annex::Base<pass_list>));
         passes.insert(passes.end(), pass_list_defs.begin(), pass_list_defs.end());
     }
-    Ref app_list = world.annex<pass_list>();
+    const Def* app_list = world.annex<pass_list>();
     for (auto pass : passes) app_list = world.app(app_list, pass);
     return app_list;
 }

--- a/src/mim/plug/core/be/ll.cpp
+++ b/src/mim/plug/core/be/ll.cpp
@@ -72,7 +72,7 @@ const char* llvm_suffix(const Def* type) {
 
 // [%mem.M, T] => T
 // TODO there may be more instances where we have to deal with this trickery
-Ref isa_mem_sigma_2(Ref type) {
+const Def* isa_mem_sigma_2(const Def* type) {
     if (auto sigma = type->isa<Sigma>())
         if (sigma->num_ops() == 2 && match<mem::M>(sigma->op(0))) return sigma->op(1);
     return {};

--- a/src/mim/plug/demo/normalizers.cpp
+++ b/src/mim/plug/demo/normalizers.cpp
@@ -4,7 +4,7 @@
 
 namespace mim::plug::demo {
 
-Ref normalize_const(Ref type, Ref, Ref arg) {
+const Def* normalize_const(const Def* type, const Def*, const Def* arg) {
     auto& world = type->world();
     return world.lit(world.type_idx(arg), 42);
 }

--- a/src/mim/plug/direct/normalizers.cpp
+++ b/src/mim/plug/direct/normalizers.cpp
@@ -5,7 +5,7 @@
 namespace mim::plug::direct {
 
 /// `cps2ds` is directly converted to `op_cps2ds_dep f` in its normalizer.
-Ref normalize_cps2ds(Ref, Ref, Ref fun) { return op_cps2ds_dep(fun); }
+const Def* normalize_cps2ds(const Def*, const Def*, const Def* fun) { return op_cps2ds_dep(fun); }
 
 MIM_direct_NORMALIZER_IMPL
 

--- a/src/mim/plug/direct/pass/ds2cps.cpp
+++ b/src/mim/plug/direct/pass/ds2cps.cpp
@@ -8,7 +8,7 @@
 
 namespace mim::plug::direct {
 
-Ref DS2CPS::rewrite(Ref def) {
+const Def* DS2CPS::rewrite(const Def* def) {
     if (auto app = def->isa<App>()) {
         if (auto lam = app->callee()->isa_mut<Lam>()) {
             world().DLOG("encountered lam app");
@@ -25,7 +25,7 @@ Ref DS2CPS::rewrite(Ref def) {
 
 /// This function generates the cps function `f_cps : cn [a:A, cn B]` for a ds function `f: [a : A] -> B`.
 /// The translation is associated in the `rewritten_` map.
-Ref DS2CPS::rewrite_lam(Lam* lam) {
+const Def* DS2CPS::rewrite_lam(Lam* lam) {
     if (auto i = rewritten_.find(lam); i != rewritten_.end()) return i->second;
 
     // only look at lambdas (ds not cps)

--- a/src/mim/plug/matrix/normalizers.cpp
+++ b/src/mim/plug/matrix/normalizers.cpp
@@ -16,7 +16,7 @@ namespace mim::plug::matrix {
 /// - read(transpose m, (i,j)) -> read(m, (j,i)) (TODO: check for map_reduce)
 /// - read(product m1 m2, (i,j)) -> ... (TODO: check with map_reduce)
 /// - read (map_reduce f) idx = loop f idx (TODO: implement => use inner loop from lowering phase)
-Ref normalize_read(Ref type, Ref, Ref arg) {
+const Def* normalize_read(const Def* type, const Def*, const Def* arg) {
     auto& world            = type->world();
     auto [mem, mat, index] = arg->projs<3>();
 
@@ -38,7 +38,7 @@ Ref normalize_read(Ref type, Ref, Ref arg) {
 
 /// Normalizer for write operations
 /// TODO: implement
-Ref normalize_insert(Ref, Ref, Ref) { return {}; }
+const Def* normalize_insert(const Def*, const Def*, const Def*) { return {}; }
 
 /// Normalizer for transpose operations
 /// - transpose (constMat v) -> cosntMat v (TODO: implement)
@@ -46,7 +46,7 @@ Ref normalize_insert(Ref, Ref, Ref) { return {}; }
 /// - transpose (tranpose m) -> m (TODO: implement)
 
 /// - shape (\@mat n (k1,k2,...,kn) i) -> (k1,k2,...,kn)\#i (TODO: implement)
-Ref normalize_shape(Ref type, Ref callee, Ref arg) {
+const Def* normalize_shape(const Def* type, const Def* callee, const Def* arg) {
     auto& world                   = type->world();
     auto [mat, index]             = arg->projs<2>();
     auto [dims, sizes, body_type] = match<Mat, false>(mat->type())->args<3>();
@@ -86,9 +86,9 @@ u64 get_max_index(u64 init, Defs inputs) {
 /// - TODO: map_reduce (..., ((idx,map_reduce([out, ]...), ...))) -> unify idx, out (out is implicit), name vars apart
 ///   requires: same reduction, distributive reduction
 /// we assume distributivity of the reduction function
-Ref normalize_map_reduce(Ref, Ref, Ref) { return {}; }
-Ref normalize_prod(Ref, Ref, Ref) { return {}; }
-Ref normalize_transpose(Ref, Ref, Ref) { return {}; }
+const Def* normalize_map_reduce(const Def*, const Def*, const Def*) { return {}; }
+const Def* normalize_prod(const Def*, const Def*, const Def*) { return {}; }
+const Def* normalize_transpose(const Def*, const Def*, const Def*) { return {}; }
 
 MIM_matrix_NORMALIZER_IMPL
 

--- a/src/mim/plug/matrix/pass/lower_matrix_highlevel.cpp
+++ b/src/mim/plug/matrix/pass/lower_matrix_highlevel.cpp
@@ -14,7 +14,7 @@ namespace mim::plug::matrix {
 
 namespace {
 
-std::optional<Ref> internal_function_of_axiom(const Axiom* axiom, Ref meta_args, Ref args) {
+std::optional<const Def*> internal_function_of_axiom(const Axiom* axiom, const Def* meta_args, const Def* args) {
     auto& world = axiom->world();
     auto name   = axiom->sym().str();
     find_and_replace(name, ".", "_");
@@ -32,14 +32,14 @@ std::optional<Ref> internal_function_of_axiom(const Axiom* axiom, Ref meta_args,
 
 } // namespace
 
-Ref LowerMatrixHighLevelMapRed::rewrite(Ref def) {
+const Def* LowerMatrixHighLevelMapRed::rewrite(const Def* def) {
     if (auto i = rewritten.find(def); i != rewritten.end()) return i->second;
     auto new_def   = rewrite_(def);
     rewritten[def] = new_def;
     return rewritten[def];
 }
 
-Ref LowerMatrixHighLevelMapRed::rewrite_(Ref def) {
+const Def* LowerMatrixHighLevelMapRed::rewrite_(const Def* def) {
     if (auto mat_ax = match<matrix::prod>(def)) {
         auto [mem, M, N]  = mat_ax->args<3>();
         auto [m, k, l, w] = mat_ax->decurry()->args<4>();

--- a/src/mim/plug/matrix/pass/lower_matrix_lowlevel.cpp
+++ b/src/mim/plug/matrix/pass/lower_matrix_lowlevel.cpp
@@ -21,7 +21,7 @@ namespace mim::plug::matrix {
 
 namespace {
 
-Ref op_lea_tuple(Ref arr, Ref tuple) {
+const Def* op_lea_tuple(const Def* arr, const Def* tuple) {
     auto& world = arr->world();
     world.DLOG("op_lea_tuple arr {} : {}", arr, arr->type());
     auto n       = tuple->num_projs();
@@ -30,7 +30,7 @@ Ref op_lea_tuple(Ref arr, Ref tuple) {
     return element;
 }
 
-Ref op_pack_tuple(u64 n, Ref tuple, Ref val) {
+const Def* op_pack_tuple(u64 n, const Def* tuple, const Def* val) {
     auto& world = val->world();
     // TODO: find out why num_projs is wrong
     auto element = val;
@@ -43,7 +43,7 @@ Ref op_pack_tuple(u64 n, Ref tuple, Ref val) {
     return element;
 }
 
-Ref arr_ty_of_matrix_ty(Ref S, Ref T) {
+const Def* arr_ty_of_matrix_ty(const Def* S, const Def* T) {
     auto& world = S->world();
     auto n      = S->num_projs();
     auto arr_ty = T;
@@ -56,7 +56,7 @@ Ref arr_ty_of_matrix_ty(Ref S, Ref T) {
 
 } // namespace
 
-Ref LowerMatrixLowLevel::rewrite_imm(Ref def) {
+const Def* LowerMatrixLowLevel::rewrite_imm(const Def* def) {
     assert(!match<matrix::map_reduce>(def) && "map_reduce should have been lowered to for loops by now");
     assert(!match<matrix::shape>(def) && "high level operations should have been lowered to for loops by now");
     assert(!match<matrix::prod>(def) && "high level operations should have been lowered to for loops by now");

--- a/src/mim/plug/matrix/pass/lower_matrix_mediumlevel.cpp
+++ b/src/mim/plug/matrix/pass/lower_matrix_mediumlevel.cpp
@@ -16,14 +16,14 @@ using namespace std::string_literals;
 
 namespace mim::plug::matrix {
 
-Ref LowerMatrixMediumLevel::rewrite(Ref def) {
+const Def* LowerMatrixMediumLevel::rewrite(const Def* def) {
     if (auto i = rewritten.find(def); i != rewritten.end()) return i->second;
     auto new_def   = rewrite_(def);
     rewritten[def] = new_def;
     return rewritten[def];
 }
 
-std::pair<Lam*, Ref> counting_for(Ref bound, DefVec acc, Ref exit, const char* name = "for_body") {
+std::pair<Lam*, const Def*> counting_for(const Def* bound, DefVec acc, const Def* exit, const char* name = "for_body") {
     auto& world = bound->world();
     auto acc_ty = world.tuple(acc)->type();
     auto body
@@ -35,7 +35,7 @@ std::pair<Lam*, Ref> counting_for(Ref bound, DefVec acc, Ref exit, const char* n
 // TODO: compare with other impala version (why is one easier than the other?)
 // TODO: replace sum_ptr by using sum as accumulator
 // TODO: extract inner loop into function (for read normalizer)
-Ref LowerMatrixMediumLevel::rewrite_(Ref def) {
+const Def* LowerMatrixMediumLevel::rewrite_(const Def* def) {
     if (auto map_reduce_ax = match<matrix::map_reduce>(def); map_reduce_ax) {
         // meta arguments:
         // * n = out-count, (nat)
@@ -81,15 +81,15 @@ Ref LowerMatrixMediumLevel::rewrite_(Ref def) {
         // return matrix
         // ```
 
-        absl::flat_hash_map<u64, Ref> dims;         // idx ↦ nat (size bound = dimension)
-        absl::flat_hash_map<u64, Ref> raw_iterator; // idx ↦ I32
-        absl::flat_hash_map<u64, Ref> iterator;     // idx ↦ %Idx (S/NI#i)
-        Vector<u64> out_indices;                    // output indices 0..n-1
-        Vector<u64> in_indices;                     // input indices ≥ n
+        absl::flat_hash_map<u64, const Def*> dims;         // idx ↦ nat (size bound = dimension)
+        absl::flat_hash_map<u64, const Def*> raw_iterator; // idx ↦ I32
+        absl::flat_hash_map<u64, const Def*> iterator;     // idx ↦ %Idx (S/NI#i)
+        Vector<u64> out_indices;                           // output indices 0..n-1
+        Vector<u64> in_indices;                            // input indices ≥ n
 
-        Vector<Ref> output_dims;   // i<n ↦ nat (dimension S#i)
-        Vector<DefVec> input_dims; // i<m ↦ j<NI#i ↦ nat (dimension SI#i#j)
-        Vector<u64> n_input;       // i<m ↦ nat (number of dimensions of SI#i)
+        Vector<const Def*> output_dims; // i<n ↦ nat (dimension S#i)
+        Vector<DefVec> input_dims;      // i<m ↦ j<NI#i ↦ nat (dimension SI#i#j)
+        Vector<u64> n_input;            // i<m ↦ nat (number of dimensions of SI#i)
 
         auto n_lit = n->isa<Lit>();
         auto m_lit = m->isa<Lit>();

--- a/src/mim/plug/mem/normalizers.cpp
+++ b/src/mim/plug/mem/normalizers.cpp
@@ -4,7 +4,7 @@
 
 namespace mim::plug::mem {
 
-Ref normalize_lea(Ref, Ref, Ref arg) {
+const Def* normalize_lea(const Def*, const Def*, const Def* arg) {
     auto [ptr, index]          = arg->projs<2>();
     auto [pointee, addr_space] = force<Ptr>(ptr->type())->args<2>();
 
@@ -14,7 +14,7 @@ Ref normalize_lea(Ref, Ref, Ref arg) {
     return {};
 }
 
-Ref normalize_load(Ref type, Ref, Ref arg) {
+const Def* normalize_load(const Def* type, const Def*, const Def* arg) {
     auto& world                = type->world();
     auto [mem, ptr]            = arg->projs<2>();
     auto [pointee, addr_space] = force<Ptr>(ptr->type())->args<2>();
@@ -28,15 +28,15 @@ Ref normalize_load(Ref type, Ref, Ref arg) {
     return {};
 }
 
-Ref normalize_remem(Ref, Ref, Ref) { return {}; }
+const Def* normalize_remem(const Def*, const Def*, const Def*) { return {}; }
 
-Ref normalize_store(Ref, Ref, Ref arg) {
+const Def* normalize_store(const Def*, const Def*, const Def* arg) {
     auto [mem, ptr, val] = arg->projs<3>();
 
     if (ptr->isa<Bot>() || val->isa<Bot>()) return mem;
     if (auto pack = val->isa<Pack>(); pack && pack->body()->isa<Bot>()) return mem;
     if (auto tuple = val->isa<Tuple>()) {
-        if (std::ranges::all_of(tuple->ops(), [](Ref op) { return op->isa<Bot>(); })) return mem;
+        if (std::ranges::all_of(tuple->ops(), [](const Def* op) { return op->isa<Bot>(); })) return mem;
     }
 
     return {};

--- a/src/mim/plug/mem/pass/alloc2malloc.cpp
+++ b/src/mim/plug/mem/pass/alloc2malloc.cpp
@@ -4,7 +4,7 @@
 
 namespace mim::plug::mem {
 
-Ref Alloc2Malloc::rewrite(Ref def) {
+const Def* Alloc2Malloc::rewrite(const Def* def) {
     if (auto alloc = match<mem::alloc>(def)) {
         auto [pointee, addr_space] = alloc->decurry()->args<2>();
         return op_malloc(pointee, alloc->arg());

--- a/src/mim/plug/mem/pass/copy_prop.cpp
+++ b/src/mim/plug/mem/pass/copy_prop.cpp
@@ -7,7 +7,7 @@
 
 namespace mim::plug::mem {
 
-Ref CopyProp::rewrite(Ref def) {
+const Def* CopyProp::rewrite(const Def* def) {
     auto [app, var_lam] = isa_apped_mut_lam(def);
     if (!isa_workable(var_lam) || (bb_only_ && Lam::isa_returning(var_lam))) return def;
 
@@ -69,7 +69,7 @@ Ref CopyProp::rewrite(Ref def) {
         if (eta_exp_) eta_exp_->new2old(prop_lam, var_lam);
 
         size_t j      = 0;
-        auto new_vars = DefVec(n, [&, prop_lam = prop_lam](size_t i) -> Ref {
+        auto new_vars = DefVec(n, [&, prop_lam = prop_lam](size_t i) -> const Def* {
             switch (lattice[i]) {
                 case Lattice::Dead: return proxy(var_lam->var(n, i)->type(), {var_lam, world().lit_nat(i)}, Varxy);
                 case Lattice::Prop: return args[i];

--- a/src/mim/plug/mem/pass/remem_elim.cpp
+++ b/src/mim/plug/mem/pass/remem_elim.cpp
@@ -4,7 +4,7 @@
 
 namespace mim::plug::mem {
 
-Ref RememElim::rewrite(Ref def) {
+const Def* RememElim::rewrite(const Def* def) {
     if (auto remem = match<mem::remem>(def)) return remem->arg();
     return def;
 }

--- a/src/mim/plug/refly/normalizers.cpp
+++ b/src/mim/plug/refly/normalizers.cpp
@@ -11,7 +11,7 @@ static_assert(sizeof(void*) <= sizeof(u64), "pointer doesn't fit into Lit");
 namespace {
 
 // The trick is that we simply "box" the pointer of @p def inside a Lit of type `%refly.Code`.
-Ref do_reify(const Def* def) {
+const Def* do_reify(const Def* def) {
     auto& world = def->world();
     return world.lit(world.call<Code>(def->type()), reinterpret_cast<u64>(def));
 }
@@ -19,7 +19,7 @@ Ref do_reify(const Def* def) {
 // And here we are doing the reverse to retrieve the original pointer again.
 const Def* do_reflect(const Def* def) { return reinterpret_cast<const Def*>(def->as<Lit>()->get()); }
 
-void debug_print(Ref lvl, Ref def) {
+void debug_print(const Def* lvl, const Def* def) {
     auto& world = def->world();
     auto level  = Log::Level::Debug;
     if (auto l = Lit::isa(lvl))
@@ -36,17 +36,17 @@ void debug_print(Ref lvl, Ref def) {
 
 } // namespace
 
-template<dbg id> Ref normalize_dbg(Ref, Ref, Ref arg) {
+template<dbg id> const Def* normalize_dbg(const Def*, const Def*, const Def* arg) {
     auto [lvl, x] = arg->projs<2>();
     debug_print(lvl, x);
-    return id == dbg::perm ? Ref() : Ref(x);
+    return id == dbg::perm ? nullptr : x;
 }
 
-Ref normalize_reify(Ref, Ref, Ref arg) { return do_reify(arg); }
+const Def* normalize_reify(const Def*, const Def*, const Def* arg) { return do_reify(arg); }
 
-Ref normalize_reflect(Ref, Ref, Ref arg) { return do_reflect(arg); }
+const Def* normalize_reflect(const Def*, const Def*, const Def* arg) { return do_reflect(arg); }
 
-Ref normalize_refine(Ref, Ref, Ref arg) {
+const Def* normalize_refine(const Def*, const Def*, const Def* arg) {
     auto [code, i, x] = arg->projs<3>();
     if (auto l = Lit::isa(i)) {
         auto def = do_reflect(code);
@@ -56,7 +56,7 @@ Ref normalize_refine(Ref, Ref, Ref arg) {
     return {};
 }
 
-Ref normalize_gid(Ref, Ref, Ref arg) { return arg->world().lit_nat(arg->gid()); }
+const Def* normalize_gid(const Def*, const Def*, const Def* arg) { return arg->world().lit_nat(arg->gid()); }
 
 MIM_refly_NORMALIZER_IMPL
 

--- a/src/mim/plug/refly/pass/remove_perm.cpp
+++ b/src/mim/plug/refly/pass/remove_perm.cpp
@@ -4,7 +4,7 @@
 
 namespace mim::plug::refly {
 
-Ref RemoveDbgPerm::rewrite(Ref def) {
+const Def* RemoveDbgPerm::rewrite(const Def* def) {
     if (auto dbg_perm = match(dbg::perm, def)) {
         auto [lvl, x] = dbg_perm->args<2>();
         world().DLOG("dbg_perm: {}", x);

--- a/src/mim/plug/refly/refly.mim
+++ b/src/mim/plug/refly/refly.mim
@@ -2,7 +2,7 @@
 ///
 /// @see mim::plug::refly
 ///
-/// The refly plugin allows to [reify](https://en.wikipedia.org/wiki/Reification_(computer_science)) and [reflect](https://en.wikipedia.org/wiki/Reflective_programming) MimIR's own representation.
+/// The refly plugin allows to [reify](https://en.wikipedia.org/wiki/Reification_(computer_science)) and [reflect](https://en.wikipedia.org/wiki/const Def*lective_programming) MimIR's own representation.
 ///
 /// [TOC]
 ///
@@ -14,7 +14,7 @@ import compile;
 ///
 axm %refly.Code: * → *;
 ///
-/// ## Reify/Reflect
+/// ## Reify/const Def*lect
 ///
 /// ### %%refly.reify
 ///

--- a/src/mim/plug/regex/dfa2matcher.cpp
+++ b/src/mim/plug/regex/dfa2matcher.cpp
@@ -63,7 +63,7 @@ DFAMap<Ranges> transitions_to_ranges(World& w, const DFANode* state) {
     return state2ranges;
 }
 
-Ref match_range(Ref c, nat_t lo, nat_t hi) {
+const Def* match_range(const Def* c, nat_t lo, nat_t hi) {
     World& w = c->world();
     if (lo == 0 && hi == 255) return w.lit_tt();
 
@@ -73,9 +73,9 @@ Ref match_range(Ref c, nat_t lo, nat_t hi) {
     return w.call(core::bit2::and_, w.lit_nat(2), w.tuple({below_hi, above_lo}));
 }
 
-DFAMap<Ref> create_check_match_transitions_from(Ref c, const DFANode* state) {
+DFAMap<const Def*> create_check_match_transitions_from(const Def* c, const DFANode* state) {
     World& w = c->world();
-    DFAMap<Ref> state2check;
+    DFAMap<const Def*> state2check;
 
     auto state2ranges = transitions_to_ranges(w, state);
 
@@ -92,7 +92,7 @@ DFAMap<Ref> create_check_match_transitions_from(Ref c, const DFANode* state) {
 
 } // namespace
 
-extern "C" const Def* dfa2matcher(World& w, const DFA& dfa, Ref n) {
+extern "C" const Def* dfa2matcher(World& w, const DFA& dfa, const Def* n) {
     w.DLOG("dfa to match: {}", dfa);
 
     auto states = dfa.get_reachable_states();

--- a/src/mim/plug/regex/pass/lower_regex.cpp
+++ b/src/mim/plug/regex/pass/lower_regex.cpp
@@ -18,10 +18,10 @@
 namespace mim::plug::regex {
 
 namespace {
-Ref wrap_in_cps2ds(Ref callee) { return direct::op_cps2ds_dep(callee); }
+const Def* wrap_in_cps2ds(const Def* callee) { return direct::op_cps2ds_dep(callee); }
 } // namespace
 
-Ref LowerRegex::rewrite(Ref def) {
+const Def* LowerRegex::rewrite(const Def* def) {
     const Def* new_app = def;
 
     if (auto app = def->isa<App>()) {

--- a/src/mim/plug/regex/regex2nfa.cpp
+++ b/src/mim/plug/regex/regex2nfa.cpp
@@ -20,13 +20,14 @@ struct Regex2NfaConverter {
         for (auto i = lb; i <= ub; ++i) from->add_transition(to, i);
     }
 
-    void add_range_transitions(automaton::NFANode* from, automaton::NFANode* to, Ref lit0, Ref lit1) {
+    void add_range_transitions(automaton::NFANode* from, automaton::NFANode* to, const Def* lit0, const Def* lit1) {
         auto lb = lit0->as<Lit>()->get();
         auto ub = lit1->as<Lit>()->get();
         add_range_transitions(from, to, lb, ub);
     }
 
-    void convert(Ref regex, automaton::NFANode* start, automaton::NFANode* end, automaton::NFANode* error = nullptr) {
+    void
+    convert(const Def* regex, automaton::NFANode* start, automaton::NFANode* end, automaton::NFANode* error = nullptr) {
         if (auto conj = mim::match<regex::conj>(regex)) {
             auto middle = nfa_->add_state();
             convert(conj->arg(0), start, middle, error);
@@ -70,7 +71,7 @@ struct Regex2NfaConverter {
         }
     }
 
-    void convert(Ref regex) {
+    void convert(const Def* regex) {
         auto start = nfa_->add_state();
         nfa_->set_start(start);
         auto end = nfa_->add_state();
@@ -86,7 +87,7 @@ private:
 
 } // namespace
 
-std::unique_ptr<automaton::NFA> regex2nfa(Ref regex) {
+std::unique_ptr<automaton::NFA> regex2nfa(const Def* regex) {
     Regex2NfaConverter converter;
     converter.convert(regex);
     return converter.nfa();
@@ -94,4 +95,4 @@ std::unique_ptr<automaton::NFA> regex2nfa(Ref regex) {
 
 } // namespace mim::plug::regex
 
-extern "C" automaton::NFA* regex2nfa(Ref regex) { return mim::plug::regex::regex2nfa(regex).release(); }
+extern "C" automaton::NFA* regex2nfa(const Def* regex) { return mim::plug::regex::regex2nfa(regex).release(); }

--- a/src/mim/rewrite.cpp
+++ b/src/mim/rewrite.cpp
@@ -6,14 +6,14 @@
 
 namespace mim {
 
-Ref Rewriter::rewrite(Ref old_def) {
+const Def* Rewriter::rewrite(const Def* old_def) {
     if (old_def->isa<Univ>()) return world().univ();
     if (auto i = old2new_.find(old_def); i != old2new_.end()) return i->second;
     if (auto old_mut = old_def->isa_mut()) return rewrite_mut(old_mut);
     return map(old_def, rewrite_imm(old_def));
 }
 
-Ref Rewriter::rewrite_imm(Ref old_def) {
+const Def* Rewriter::rewrite_imm(const Def* old_def) {
     // Extracts are used as conditional branches: make sure that we don't rewrite unreachable stuff.
     if (auto extract = old_def->isa<Extract>()) {
         if (auto index = Lit::isa(rewrite(extract->index()))) {
@@ -30,7 +30,7 @@ Ref Rewriter::rewrite_imm(Ref old_def) {
     return old_def->rebuild(world(), new_type, new_ops);
 }
 
-Ref Rewriter::rewrite_mut(Def* old_mut) {
+const Def* Rewriter::rewrite_mut(Def* old_mut) {
     auto new_type = rewrite(old_mut->type());
     auto new_mut  = old_mut->stub(world(), new_type);
     map(old_mut, new_mut);

--- a/src/mim/tuple.cpp
+++ b/src/mim/tuple.cpp
@@ -9,7 +9,7 @@
 namespace mim {
 
 namespace {
-bool should_flatten(Ref def) {
+bool should_flatten(const Def* def) {
     auto type = (def->is_term() ? def->type() : def);
     if (type->isa<Sigma>()) return true;
     if (auto arr = type->isa<Arr>()) {
@@ -19,12 +19,12 @@ bool should_flatten(Ref def) {
     return false;
 }
 
-bool mut_val_or_typ(Ref def) {
+bool mut_val_or_typ(const Def* def) {
     auto typ = def->is_term() ? def->type() : def;
     return typ->isa_mut();
 }
 
-Ref unflatten(Defs defs, Ref type, size_t& j, bool flatten_muts) {
+const Def* unflatten(Defs defs, const Def* type, size_t& j, bool flatten_muts) {
     if (!defs.empty() && defs[0]->type() == type) return defs[j++];
     if (auto a = type->isa_lit_arity();
         flatten_muts == mut_val_or_typ(type) && a && *a != 1 && a <= type->world().flags().scalarize_threshold) {
@@ -37,22 +37,22 @@ Ref unflatten(Defs defs, Ref type, size_t& j, bool flatten_muts) {
 }
 } // namespace
 
-Ref Pack::shape() const {
+const Def* Pack::shape() const {
     if (auto arr = type()->isa<Arr>()) return arr->shape();
     if (type() == world().sigma()) return world().lit_nat_0();
     return world().lit_nat_1();
 }
 
-bool is_unit(Ref def) { return def->type() == def->world().sigma(); }
+bool is_unit(const Def* def) { return def->type() == def->world().sigma(); }
 
-std::string tuple2str(Ref def) {
+std::string tuple2str(const Def* def) {
     if (def == nullptr) return {};
 
     auto array = def->projs(Lit::as(def->arity()), [](auto op) { return Lit::as(op); });
     return std::string(array.begin(), array.end());
 }
 
-size_t flatten(DefVec& ops, Ref def, bool flatten_muts) {
+size_t flatten(DefVec& ops, const Def* def, bool flatten_muts) {
     if (auto a = def->isa_lit_arity(); a && *a != 1 && should_flatten(def) && flatten_muts == mut_val_or_typ(def)) {
         auto n = 0;
         for (size_t i = 0; i != *a; ++i) n += flatten(ops, def->proj(*a, i), flatten_muts);
@@ -63,24 +63,24 @@ size_t flatten(DefVec& ops, Ref def, bool flatten_muts) {
     }
 }
 
-Ref flatten(Ref def) {
+const Def* flatten(const Def* def) {
     if (!should_flatten(def)) return def;
     DefVec ops;
     flatten(ops, def);
     return def->is_term() ? def->world().tuple(def->type(), ops) : def->world().sigma(ops);
 }
 
-Ref unflatten(Defs defs, Ref type, bool flatten_muts) {
+const Def* unflatten(Defs defs, const Def* type, bool flatten_muts) {
     size_t j = 0;
     auto def = unflatten(defs, type, j, flatten_muts);
     assert(j == defs.size());
     return def;
 }
 
-Ref unflatten(Ref def, Ref type) { return unflatten(def->projs(Lit::as(def->arity())), type); }
+const Def* unflatten(const Def* def, const Def* type) { return unflatten(def->projs(Lit::as(def->arity())), type); }
 
-DefVec merge(Ref def, Defs defs) {
-    return DefVec(defs.size() + 1, [&](size_t i) { return i == 0 ? *def : defs[i - 1]; });
+DefVec merge(const Def* def, Defs defs) {
+    return DefVec(defs.size() + 1, [&](size_t i) { return i == 0 ? def : defs[i - 1]; });
 }
 
 DefVec merge(Defs a, Defs b) {
@@ -90,12 +90,12 @@ DefVec merge(Defs a, Defs b) {
     return result;
 }
 
-Ref merge_sigma(Ref def, Defs defs) {
+const Def* merge_sigma(const Def* def, Defs defs) {
     if (auto sigma = def->isa_imm<Sigma>()) return def->world().sigma(merge(sigma->ops(), defs));
     return def->world().sigma(merge(def, defs));
 }
 
-Ref merge_tuple(Ref def, Defs defs) {
+const Def* merge_tuple(const Def* def, Defs defs) {
     auto& w = def->world();
     if (auto sigma = def->type()->isa_imm<Sigma>()) {
         auto a     = sigma->num_ops();
@@ -106,7 +106,7 @@ Ref merge_tuple(Ref def, Defs defs) {
     return def->world().tuple(merge(def, defs));
 }
 
-Ref tuple_of_types(Ref t) {
+const Def* tuple_of_types(const Def* t) {
     auto& world = t->world();
     if (auto sigma = t->isa<Sigma>()) return world.tuple(sigma->ops());
     if (auto arr = t->isa<Arr>()) return world.pack(arr->shape(), arr->body());

--- a/src/mim/world.cpp
+++ b/src/mim/world.cpp
@@ -186,9 +186,10 @@ template<bool Normalize> const Def* World::implicit_app(const Def* callee, const
 
 template<bool Normalize> const Def* World::app(const Def* callee, const Def* arg) {
     callee = callee->zonk();
+    arg    = arg->zonk();
     if (auto pi = callee->type()->isa<Pi>()) {
         if (auto new_arg = Checker::assignable(pi->dom(), arg)) {
-            arg = new_arg;
+            arg = new_arg->zonk();
             if (auto imm = callee->isa_imm<Lam>()) return imm->body();
             if (auto lam = callee->isa_mut<Lam>(); lam && lam->is_set() && lam->filter() != lit_ff()) {
                 auto rw = VarRewriter(lam->has_var(), arg);
@@ -198,7 +199,8 @@ template<bool Normalize> const Def* World::app(const Def* callee, const Def* arg
                 }
             }
 
-            auto type                 = pi->reduce(arg);
+            auto type                 = pi->reduce(arg)->zonk();
+            callee                    = callee->zonk();
             auto [axiom, curry, trip] = Axiom::get(callee);
             if (axiom) {
                 curry = curry == 0 ? trip : curry;

--- a/src/mim/world.cpp
+++ b/src/mim/world.cpp
@@ -13,10 +13,11 @@
 namespace mim {
 
 namespace {
-bool is_shape(Ref s) {
+bool is_shape(const Def* s) {
     if (s->isa<Nat>()) return true;
     if (auto arr = s->isa<Arr>()) return arr->body()->isa<Nat>();
-    if (auto sig = s->isa_imm<Sigma>()) return std::ranges::all_of(sig->ops(), [](Ref op) { return op->isa<Nat>(); });
+    if (auto sig = s->isa_imm<Sigma>())
+        return std::ranges::all_of(sig->ops(), [](const Def* op) { return op->isa<Nat>(); });
 
     return false;
 }
@@ -107,14 +108,14 @@ void World::make_internal(Def* def) {
  * factory methods
  */
 
-const Type* World::type(Ref level) {
+const Type* World::type(const Def* level) {
     if (!level->type()->isa<Univ>())
         error(level->loc(), "argument `{}` to `Type` must be of type `Univ` but is of type `{}`", level, level->type());
 
     return unify<Type>(1, level)->as<Type>();
 }
 
-Ref World::uinc(Ref op, level_t offset) {
+const Def* World::uinc(const Def* op, level_t offset) {
     if (!op->type()->isa<Univ>())
         error(op->loc(), "operand '{}' of a universe increment must be of type `Univ` but is of type `{}`", op,
               op->type());
@@ -123,7 +124,7 @@ Ref World::uinc(Ref op, level_t offset) {
     return unify<UInc>(1, op, offset);
 }
 
-template<Sort sort> Ref World::umax(Defs ops_) {
+template<Sort sort> const Def* World::umax(Defs ops_) {
     // consume nested umax
     DefVec ops;
     for (auto op : ops_)
@@ -134,7 +135,7 @@ template<Sort sort> Ref World::umax(Defs ops_) {
 
     level_t lvl = 0;
     for (auto& op : ops) {
-        Ref r = op;
+        const Def* r = op;
         if (sort == Sort::Term) r = r->unfold_type();
         if (sort <= Sort::Type) r = r->unfold_type();
         if (sort <= Sort::Kind) {
@@ -169,7 +170,7 @@ template<Sort sort> Ref World::umax(Defs ops_) {
 
 // TODO more thorough & consistent checks for singleton types
 
-Ref World::var(Ref type, Def* mut) {
+const Def* World::var(const Def* type, Def* mut) {
     if (auto s = Idx::isa(type)) {
         if (auto l = Lit::isa(s); l && l == 1) return lit_0_1();
     }
@@ -178,12 +179,12 @@ Ref World::var(Ref type, Def* mut) {
     return mut->var_ = unify<Var>(1, type, mut);
 }
 
-template<bool Normalize> Ref World::implicit_app(Ref callee, Ref arg) {
+template<bool Normalize> const Def* World::implicit_app(const Def* callee, const Def* arg) {
     while (auto pi = Pi::isa_implicit(callee->type())) callee = app(callee, mut_infer(pi->dom()));
     return app<Normalize>(callee, arg);
 }
 
-template<bool Normalize> Ref World::app(Ref callee, Ref arg) {
+template<bool Normalize> const Def* World::app(const Def* callee, const Def* arg) {
     callee = callee->zonk();
     if (auto pi = callee->type()->isa<Pi>()) {
         if (auto new_arg = Checker::assignable(pi->dom(), arg)) {
@@ -224,7 +225,7 @@ template<bool Normalize> Ref World::app(Ref callee, Ref arg) {
         .error(callee->loc(), "'{}' <--- callee type", callee->type());
 }
 
-Ref World::raw_app(Ref type, Ref callee, Ref arg) {
+const Def* World::raw_app(const Def* type, const Def* callee, const Def* arg) {
     auto [axiom, curry, trip] = Axiom::get(callee);
     if (axiom) {
         curry = curry == 0 ? trip : curry;
@@ -234,11 +235,11 @@ Ref World::raw_app(Ref type, Ref callee, Ref arg) {
     return raw_app(axiom, curry, trip, type, callee, arg);
 }
 
-Ref World::raw_app(const Axiom* axiom, u8 curry, u8 trip, Ref type, Ref callee, Ref arg) {
+const Def* World::raw_app(const Axiom* axiom, u8 curry, u8 trip, const Def* type, const Def* callee, const Def* arg) {
     return unify<App>(2, axiom, curry, trip, type, callee, arg);
 }
 
-Ref World::sigma(Defs ops) {
+const Def* World::sigma(Defs ops) {
     auto n = ops.size();
     if (n == 0) return sigma();
     if (n == 1) return ops[0];
@@ -246,7 +247,7 @@ Ref World::sigma(Defs ops) {
     return unify<Sigma>(ops.size(), Sigma::infer(*this, ops), ops);
 }
 
-Ref World::tuple(Defs ops) {
+const Def* World::tuple(Defs ops) {
     if (ops.size() == 1) return ops[0];
 
     auto sigma = infer_sigma(*this, ops);
@@ -258,7 +259,7 @@ Ref World::tuple(Defs ops) {
     return new_t;
 }
 
-Ref World::tuple(Ref type, Defs ops) {
+const Def* World::tuple(const Def* type, Defs ops) {
     // TODO type-check type vs inferred type
 
     auto n = ops.size();
@@ -293,13 +294,13 @@ Ref World::tuple(Ref type, Defs ops) {
     return unify<Tuple>(ops.size(), type, ops);
 }
 
-Ref World::tuple(Sym sym) {
+const Def* World::tuple(Sym sym) {
     DefVec defs;
     std::ranges::transform(sym, std::back_inserter(defs), [this](auto c) { return lit_i8(c); });
     return tuple(defs);
 }
 
-Ref World::extract(Ref d, Ref index) {
+const Def* World::extract(const Def* d, const Def* index) {
     if (index->isa<Tuple>()) {
         auto n   = index->num_ops();
         auto idx = DefVec(n, [&](size_t i) { return index->op(i); });
@@ -310,8 +311,8 @@ Ref World::extract(Ref d, Ref index) {
         return tuple(ops);
     }
 
-    Ref size = Idx::isa(index->type());
-    Ref type = d->unfold_type()->zonk();
+    const Def* size = Idx::isa(index->type());
+    const Def* type = d->unfold_type()->zonk();
 
     if (auto l = Lit::isa(size); l && *l == 1) {
         if (auto l = Lit::isa(index); !l || *l != 0) WLOG("unknown Idx of size 1: {}", index);
@@ -361,7 +362,7 @@ Ref World::extract(Ref d, Ref index) {
     return unify<Extract>(2, elem_t, d, index);
 }
 
-Ref World::insert(Ref d, Ref index, Ref val) {
+const Def* World::insert(const Def* d, const Def* index, const Def* val) {
     auto type = d->unfold_type();
     auto size = Idx::isa(index->type());
     auto lidx = Lit::isa(index);
@@ -405,7 +406,7 @@ Ref World::insert(Ref d, Ref index, Ref val) {
 }
 
 // TODO merge this code with pack
-Ref World::arr(Ref shape, Ref body) {
+const Def* World::arr(const Def* shape, const Def* body) {
     if (!is_shape(shape->type())) error(shape->loc(), "expected shape but got '{}' of type '{}'", shape, shape->type());
 
     if (auto a = Lit::isa(shape)) {
@@ -432,7 +433,7 @@ Ref World::arr(Ref shape, Ref body) {
     return unify<Arr>(2, body->unfold_type(), shape, body);
 }
 
-Ref World::pack(Ref shape, Ref body) {
+const Def* World::pack(const Def* shape, const Def* body) {
     if (!is_shape(shape->type())) error(shape->loc(), "expected shape but got '{}' of type '{}'", shape, shape->type());
 
     if (auto a = Lit::isa(shape)) {
@@ -452,17 +453,17 @@ Ref World::pack(Ref shape, Ref body) {
     return unify<Pack>(1, type, body);
 }
 
-Ref World::arr(Defs shape, Ref body) {
+const Def* World::arr(Defs shape, const Def* body) {
     if (shape.empty()) return body;
     return arr(shape.rsubspan(1), arr(shape.back(), body));
 }
 
-Ref World::pack(Defs shape, Ref body) {
+const Def* World::pack(Defs shape, const Def* body) {
     if (shape.empty()) return body;
     return pack(shape.rsubspan(1), pack(shape.back(), body));
 }
 
-const Lit* World::lit(Ref type, u64 val) {
+const Lit* World::lit(const Def* type, u64 val) {
     if (auto size = Idx::isa(type)) {
         if (auto s = Lit::isa(size)) {
             if (*s != 0 && val >= *s) error(type->loc(), "index '{}' does not fit within arity '{}'", size, val);
@@ -478,23 +479,23 @@ const Lit* World::lit(Ref type, u64 val) {
  * set
  */
 
-template<bool Up> Ref World::ext(Ref type) {
+template<bool Up> const Def* World::ext(const Def* type) {
     if (auto arr = type->isa<Arr>()) return pack(arr->shape(), ext<Up>(arr->body()));
     if (auto sigma = type->isa<Sigma>())
         return tuple(sigma, DefVec(sigma->num_ops(), [&](size_t i) { return ext<Up>(sigma->op(i)); }));
     return unify<TExt<Up>>(0, type);
 }
 
-template<bool Up> Ref World::bound(Defs ops) {
+template<bool Up> const Def* World::bound(Defs ops) {
     auto kind = umax<Sort::Type>(ops);
 
     // has ext<Up> value?
-    if (std::ranges::any_of(ops, [&](Ref op) { return Up ? bool(op->isa<Top>()) : bool(op->isa<Bot>()); }))
+    if (std::ranges::any_of(ops, [&](const Def* op) { return Up ? bool(op->isa<Top>()) : bool(op->isa<Bot>()); }))
         return ext<Up>(kind);
 
     // ignore: ext<!Up>
     DefVec cpy(ops.begin(), ops.end());
-    auto [_, end] = std::ranges::copy_if(ops, cpy.begin(), [&](Ref op) { return !op->isa<Ext>(); });
+    auto [_, end] = std::ranges::copy_if(ops, cpy.begin(), [&](const Def* op) { return !op->isa<Ext>(); });
 
     // sort and remove duplicates
     std::sort(cpy.begin(), end, GIDLt<const Def*>());
@@ -509,7 +510,7 @@ template<bool Up> Ref World::bound(Defs ops) {
     return unify<TBound<Up>>(cpy.size(), kind, cpy);
 }
 
-Ref World::ac(Ref type, Defs ops) {
+const Def* World::ac(const Def* type, Defs ops) {
     if (type->isa<Meet>()) {
         auto types = DefVec(ops.size(), [&](size_t i) { return ops[i]->type(); });
         return unify<Ac>(ops.size(), meet(types), ops);
@@ -519,16 +520,16 @@ Ref World::ac(Ref type, Defs ops) {
     return ops[0];
 }
 
-Ref World::ac(Defs ops) { return ac(umax<Sort::Term>(ops), ops); }
+const Def* World::ac(Defs ops) { return ac(umax<Sort::Term>(ops), ops); }
 
-Ref World::vel(Ref type, Ref value) {
+const Def* World::vel(const Def* type, const Def* value) {
     if (type->isa<Join>()) return unify<Vel>(1, type, value);
     return value;
 }
 
-Ref World::pick(Ref type, Ref value) { return unify<Pick>(1, type, value); }
+const Def* World::pick(const Def* type, const Def* value) { return unify<Pick>(1, type, value); }
 
-Ref World::test(Ref value, Ref probe, Ref match, Ref clash) {
+const Def* World::test(const Def* value, const Def* probe, const Def* match, const Def* clash) {
     auto m_pi = match->type()->isa<Pi>();
     auto c_pi = clash->type()->isa<Pi>();
 
@@ -542,7 +543,7 @@ Ref World::test(Ref value, Ref probe, Ref match, Ref clash) {
     return unify<Test>(4, pi(c_pi->dom(), codom), value, probe, match, clash);
 }
 
-Ref World::uniq(Ref inhabitant) { return unify<Uniq>(1, inhabitant->type()->unfold_type(), inhabitant); }
+const Def* World::uniq(const Def* inhabitant) { return unify<Uniq>(1, inhabitant->type()->unfold_type(), inhabitant); }
 
 Sym World::append_suffix(Sym symbol, std::string suffix) {
     auto name = symbol.str();
@@ -572,7 +573,7 @@ Sym World::append_suffix(Sym symbol, std::string suffix) {
 
 void World::breakpoint(u32 gid) { state_.breakpoints.emplace(gid); }
 
-Ref World::gid2def(u32 gid) {
+const Def* World::gid2def(u32 gid) {
     auto i = std::ranges::find_if(move_.defs, [=](auto def) { return def->gid() == gid; });
     if (i == move_.defs.end()) return nullptr;
     return *i;
@@ -587,18 +588,18 @@ World& World::verify() {
 #endif
 
 #ifndef DOXYGEN
-template Ref World::umax<Sort::Term>(Defs);
-template Ref World::umax<Sort::Type>(Defs);
-template Ref World::umax<Sort::Kind>(Defs);
-template Ref World::umax<Sort::Univ>(Defs);
-template Ref World::ext<true>(Ref);
-template Ref World::ext<false>(Ref);
-template Ref World::bound<true>(Defs);
-template Ref World::bound<false>(Defs);
-template Ref World::app<true>(Ref, Ref);
-template Ref World::app<false>(Ref, Ref);
-template Ref World::implicit_app<true>(Ref, Ref);
-template Ref World::implicit_app<false>(Ref, Ref);
+template const Def* World::umax<Sort::Term>(Defs);
+template const Def* World::umax<Sort::Type>(Defs);
+template const Def* World::umax<Sort::Kind>(Defs);
+template const Def* World::umax<Sort::Univ>(Defs);
+template const Def* World::ext<true>(const Def*);
+template const Def* World::ext<false>(const Def*);
+template const Def* World::bound<true>(Defs);
+template const Def* World::bound<false>(Defs);
+template const Def* World::app<true>(const Def*, const Def*);
+template const Def* World::app<false>(const Def*, const Def*);
+template const Def* World::implicit_app<true>(const Def*, const Def*);
+template const Def* World::implicit_app<false>(const Def*, const Def*);
 #endif
 
 } // namespace mim


### PR DESCRIPTION
Remove `Ref` in favor of straight `const Def*` and specific `def = def->zonk()` operations. There is still room for improvements but current version is less complex and faster, so I'm merging now.