### PR TITLE
Bugfix/infer

### DIFF
--- a/include/mim/check.h
+++ b/include/mim/check.h
@@ -22,10 +22,6 @@ public:
         assert(op != this);
         return Def::set(0, op)->as<Hole>();
     }
-    Hole* reset(const Def* op) {
-        assert(op != this);
-        return Def::reset(0, op)->as<Hole>();
-    }
     Hole* unset() { return Def::unset()->as<Hole>(); }
     ///@}
 

--- a/include/mim/check.h
+++ b/include/mim/check.h
@@ -31,8 +31,6 @@ public:
     /// @returns the new Tuple, or `this` if unsuccessful.
     const Def* tuplefy(nat_t);
 
-    const Def* check() override { return op()->type(); }
-
     /// [Union-Find](https://en.wikipedia.org/wiki/Disjoint-set_data_structure) to unify Hole%s.
     static const Def* find(const Def*);
 

--- a/include/mim/check.h
+++ b/include/mim/check.h
@@ -26,8 +26,6 @@ public:
     ///@}
 
     /// [Union-Find](https://en.wikipedia.org/wiki/Disjoint-set_data_structure) to unify Hole%s.
-    /// Def::flags is used to keep track of rank for
-    /// [Union by rank](https://en.wikipedia.org/wiki/Disjoint-set_data_structure#Union_by_rank).
     static const Def* find(const Def*);
 
     Hole* stub(const Def* type) { return stub_(world(), type)->set(dbg()); }
@@ -38,9 +36,6 @@ public:
     static constexpr auto Node = mim::Node::Hole;
 
 private:
-    flags_t rank() const { return flags(); }
-    flags_t& rank() { return flags_; }
-
     const Def* rebuild_(World&, const Def*, Defs) const override;
     Hole* stub_(World&, const Def*) override;
 

--- a/include/mim/check.h
+++ b/include/mim/check.h
@@ -24,6 +24,7 @@ public:
     }
     ///@}
 
+    Hole* unset() { return Def::unset()->as<Hole>(); }
     Hole* stub(const Def* type) { return stub_(world(), type)->set(dbg()); }
 
     /// If unset, explode to Tuple.

--- a/include/mim/check.h
+++ b/include/mim/check.h
@@ -22,16 +22,18 @@ public:
         assert(op != this);
         return Def::set(0, op)->as<Hole>();
     }
-    Hole* unset() { return Def::unset()->as<Hole>(); }
     ///@}
 
-    /// [Union-Find](https://en.wikipedia.org/wiki/Disjoint-set_data_structure) to unify Hole%s.
-    static const Def* find(const Def*);
-
     Hole* stub(const Def* type) { return stub_(world(), type)->set(dbg()); }
+
     /// If unset, explode to Tuple.
     /// @returns the new Tuple, or `this` if unsuccessful.
     const Def* tuplefy(nat_t);
+
+    const Def* check() override { return op()->type(); }
+
+    /// [Union-Find](https://en.wikipedia.org/wiki/Disjoint-set_data_structure) to unify Hole%s.
+    static const Def* find(const Def*);
 
     static constexpr auto Node = mim::Node::Hole;
 

--- a/include/mim/check.h
+++ b/include/mim/check.h
@@ -33,7 +33,7 @@ public:
     Hole* stub(const Def* type) { return stub_(world(), type)->set(dbg()); }
     /// If unset, explode to Tuple.
     /// @returns the new Tuple, or `this` if unsuccessful.
-    const Def* tuplefy();
+    const Def* tuplefy(nat_t);
 
     static constexpr auto Node = mim::Node::Hole;
 

--- a/include/mim/def.h
+++ b/include/mim/def.h
@@ -269,25 +269,22 @@ public:
     /// @anchor set_ops
     /// You can set and change the Def::ops of a mutable after construction.
     /// However, you have to obey the following rules:
-    /// 1. If Def::is_set() is ...
-    ///     1. ... `false`, [set](@ref Def::set) the [operands](@ref Def::ops) from
+    /// If Def::is_set() is ...
+    ///     * `false`, [set](@ref Def::set) the [operands](@ref Def::ops) from
     ///         * left (`i == 0`) to
     ///         * right (`i == num_ops() - 1`).
-    ///     2. ... `true`, [reset](@ref Def::reset) the operands from left to right as in 1a.
-    /// 2. In addition, you can invoke Def::unset() at *any time* to start over with 1a:
-    /// ```
-    /// mut->unset()->set({a, b, c}); // This will always work, but should be your last resort.
-    /// ```
+    ///     * `true`, Def::unset() the operands first and then start over:
+    ///       ```
+    ///       mut->unset()->set({a, b, c});
+    ///       ```
     ///
     /// MimIR assumes that a mutable is *final*, when its last operand is set.
     /// Then, Def::check() will be invoked.
     ///@{
-    Def* set(size_t i, const Def*);                                        ///< Successively   set from left to right.
-    Def* reset(size_t i, const Def* def) { return unset(i)->set(i, def); } ///< Successively reset from left to right.
-    Def* set(Defs ops);                                                    ///< Def::set @p ops all at once.
-    Def* reset(Defs ops);                                                  ///< Def::reset @p ops all at once.
-    Def* unset();        ///< Unsets all Def::ops; works even, if not set at all or partially.
-    bool is_set() const; ///< Yields `true` if empty or the last op is set.
+    Def* set(size_t i, const Def*); ///< Successively   set from left to right.
+    Def* set(Defs ops);             ///< Def::set @p ops all at once.
+    Def* unset();                   ///< Unsets all Def::ops; works even, if not set at all or partially.
+    bool is_set() const;            ///< Yields `true` if empty or the last op is set.
     ///@}
 
     /// @name deps

--- a/include/mim/def.h
+++ b/include/mim/def.h
@@ -553,7 +553,6 @@ private:
 
     Vars free_vars(bool&, bool&, uint32_t run);
     void invalidate();
-    Def* unset(size_t i);
     const Def** ops_ptr() const {
         return reinterpret_cast<const Def**>(reinterpret_cast<char*>(const_cast<Def*>(this + 1)));
     }

--- a/include/mim/def.h
+++ b/include/mim/def.h
@@ -270,9 +270,7 @@ public:
     /// You can set and change the Def::ops of a mutable after construction.
     /// However, you have to obey the following rules:
     /// If Def::is_set() is ...
-    ///     * `false`, [set](@ref Def::set) the [operands](@ref Def::ops) from
-    ///         * left (`i == 0`) to
-    ///         * right (`i == num_ops() - 1`).
+    ///     * `false`, [set](@ref Def::set) the [operands](@ref Def::ops) from left to right.
     ///     * `true`, Def::unset() the operands first and then start over:
     ///       ```
     ///       mut->unset()->set({a, b, c});
@@ -511,8 +509,20 @@ public:
 
     /// @name Type Checking
     ///@{
-    virtual const Def* check(size_t, const Def* def) { return def; }
+
+    /// Checks whether the `i`th operand can be set to `def`.
+    /// The method returns a possibly updated version of `def` (e.g. where Hole%s have been resolved).
+    /// This is the actual `def` that will be set as the `i`th operand.
+    virtual const Def* check([[maybe_unused]] size_t i, const Def* def) { return def; }
+
+    /// After all Def::ops have ben Def::set, this method will be invoked to check the type of this mutable.
+    /// The method returns a possibly updated version of its type (e.g. where Hole%s have been resolved).
+    /// If different from Def::type, it will update its Def::type to a Def::zonk%ed version of that.
     virtual const Def* check() { return type(); }
+
+    /// If Hole%s have been filled, reconstruct the program without them.
+    /// Only gues up to but excluding other mutables.
+    /// @see https://stackoverflow.com/questions/31889048/what-does-the-ghc-source-mean-by-zonk
     const Def* zonk() const;
     ///@}
 

--- a/include/mim/def.h
+++ b/include/mim/def.h
@@ -281,7 +281,7 @@ public:
     /// MimIR assumes that a mutable is *final*, when its last operand is set.
     /// Then, Def::check() will be invoked.
     ///@{
-    Def* set(size_t i, const Def*); ///< Successively   set from left to right.
+    Def* set(size_t i, const Def*); ///< Successively set from left to right.
     Def* set(Defs ops);             ///< Def::set @p ops all at once.
     Def* unset();                   ///< Unsets all Def::ops; works even, if not set at all or partially.
     bool is_set() const;            ///< Yields `true` if empty or the last op is set.

--- a/lit/tuple/normalize.mim
+++ b/lit/tuple/normalize.mim
@@ -3,16 +3,16 @@ plugin tuple;
 plugin refly;
 
 lam f1 (a: [Nat, Bool], b: [Bool, Nat, Nat]): [ Nat, Bool ,  Bool, Nat, Nat ] = %tuple.concat  @(2, 3) (a, b);
-lam f2 (a: [Nat, Bool], b: [Bool, Nat, Nat]): [ Nat, Bool , [Bool, Nat, Nat]] = %tuple.append  @2      (a, b);
-lam f3 (a: [Nat, Bool], b: [Bool, Nat, Nat]): [[Nat, Bool],  Bool, Nat, Nat ] = %tuple.prepend @3      (a, b);
+lam f2 (a: [Nat, Bool], b: [Bool, Nat, Nat]): [ Nat, Bool , [Bool, Nat, Nat]] = %tuple.append  (a, b);
+lam f3 (a: [Nat, Bool], b: [Bool, Nat, Nat]): [[Nat, Bool],  Bool, Nat, Nat ] = %tuple.prepend (a, b);
 
 lam g1 (a: «2; Nat», b: [Bool, Nat, Nat]): [Nat, Nat,  Bool, Nat, Nat ] = %tuple.concat  @(2, 3) (a, b);
-lam g2 (a: «2; Nat», b: [Bool, Nat, Nat]): [Nat, Nat, [Bool, Nat, Nat]] = %tuple.append  @2      (a, b);
-lam g3 (a: «2; Nat», b: [Bool, Nat, Nat]): [«2; Nat» , Bool, Nat, Nat ] = %tuple.prepend @3      (a, b);
+lam g2 (a: «2; Nat», b: [Bool, Nat, Nat]): [Nat, Nat, [Bool, Nat, Nat]] = %tuple.append  (a, b);
+lam g3 (a: «2; Nat», b: [Bool, Nat, Nat]): [«2; Nat» , Bool, Nat, Nat ] = %tuple.prepend (a, b);
 
 lam h1 (a: [Nat, Bool], b: «3; Nat»): [ Nat, Bool , Nat, Nat, Nat] = %tuple.concat  @(2, 3) (a, b);
-lam h2 (a: [Nat, Bool], b: «3; Nat»): [ Nat, Bool , «3; Nat»     ] = %tuple.append  @2      (a, b);
-lam h3 (a: [Nat, Bool], b: «3; Nat»): [[Nat, Bool], Nat, Nat, Nat] = %tuple.prepend @3      (a, b);
+lam h2 (a: [Nat, Bool], b: «3; Nat»): [ Nat, Bool , «3; Nat»     ] = %tuple.append  (a, b);
+lam h3 (a: [Nat, Bool], b: «3; Nat»): [[Nat, Bool], Nat, Nat, Nat] = %tuple.prepend (a, b);
 
 let x = (1, tt);
 let y = (ff, 23, 42);
@@ -20,11 +20,11 @@ let z = %tuple.concat @(2, 3) (x, y);
 let tup = (1, tt, ff, 23, 42);
 
 let _ = %refly.equiv.struc_eq (tup, z);
-let _ = %refly.equiv.struc_eq (tt, %tuple.mem @5 (23, tup));
-let _ = %refly.equiv.struc_eq (ff, %tuple.mem @5 (24, tup));
+let _ = %refly.equiv.struc_eq (tt, %tuple.mem (23, tup));
+let _ = %refly.equiv.struc_eq (ff, %tuple.mem (24, tup));
 
 lam foo (x: Nat): [] =
     let tup = (tt, x);
-    let _ = %refly.equiv.struc_ne (tt, %tuple.mem @2 (23, tup));
-    let _ = %refly.equiv.struc_ne (ff, %tuple.mem @2 (24, tup));
+    let _ = %refly.equiv.struc_ne (tt, %tuple.mem (23, tup));
+    let _ = %refly.equiv.struc_ne (ff, %tuple.mem (24, tup));
     ()

--- a/lit/tuple/normalize.mim
+++ b/lit/tuple/normalize.mim
@@ -2,21 +2,21 @@
 plugin tuple;
 plugin refly;
 
-lam f1 (a: [Nat, Bool], b: [Bool, Nat, Nat]): [ Nat, Bool ,  Bool, Nat, Nat ] = %tuple.concat  @(2, 3) (a, b);
+lam f1 (a: [Nat, Bool], b: [Bool, Nat, Nat]): [ Nat, Bool ,  Bool, Nat, Nat ] = %tuple.concat  (a, b);
 lam f2 (a: [Nat, Bool], b: [Bool, Nat, Nat]): [ Nat, Bool , [Bool, Nat, Nat]] = %tuple.append  (a, b);
 lam f3 (a: [Nat, Bool], b: [Bool, Nat, Nat]): [[Nat, Bool],  Bool, Nat, Nat ] = %tuple.prepend (a, b);
 
-lam g1 (a: «2; Nat», b: [Bool, Nat, Nat]): [Nat, Nat,  Bool, Nat, Nat ] = %tuple.concat  @(2, 3) (a, b);
+lam g1 (a: «2; Nat», b: [Bool, Nat, Nat]): [Nat, Nat,  Bool, Nat, Nat ] = %tuple.concat  (a, b);
 lam g2 (a: «2; Nat», b: [Bool, Nat, Nat]): [Nat, Nat, [Bool, Nat, Nat]] = %tuple.append  (a, b);
 lam g3 (a: «2; Nat», b: [Bool, Nat, Nat]): [«2; Nat» , Bool, Nat, Nat ] = %tuple.prepend (a, b);
 
-lam h1 (a: [Nat, Bool], b: «3; Nat»): [ Nat, Bool , Nat, Nat, Nat] = %tuple.concat  @(2, 3) (a, b);
+lam h1 (a: [Nat, Bool], b: «3; Nat»): [ Nat, Bool , Nat, Nat, Nat] = %tuple.concat  (a, b);
 lam h2 (a: [Nat, Bool], b: «3; Nat»): [ Nat, Bool , «3; Nat»     ] = %tuple.append  (a, b);
 lam h3 (a: [Nat, Bool], b: «3; Nat»): [[Nat, Bool], Nat, Nat, Nat] = %tuple.prepend (a, b);
 
 let x = (1, tt);
 let y = (ff, 23, 42);
-let z = %tuple.concat @(2, 3) (x, y);
+let z = %tuple.concat (x, y);
 let tup = (1, tt, ff, 23, 42);
 
 let _ = %refly.equiv.struc_eq (tup, z);

--- a/src/mim/check.cpp
+++ b/src/mim/check.cpp
@@ -42,19 +42,19 @@ const Def* Def::zonk() const {
  */
 
 const Def* Hole::find(const Def* def) {
-    auto hole = def->isa_mut<Hole>();
-    if (!hole) return def; // early exit if def isn't a Hole
+    auto hole1 = def->isa_mut<Hole>();
+    if (!hole1 || !hole1->op()) return def; // early exit if def isn't a Hole or unset;
 
     // find root
     auto res = def;
-    while (hole && hole->op()) res = hole->op(), hole = res->isa_mut<Hole>();
+    for (auto hole = hole1; hole && hole->op(); res = hole->op(), hole = res->isa_mut<Hole>()) {}
 
     // path compression
-    hole = def->isa_mut<Hole>();
-    while (hole && hole->op()) {
+    for (auto hole = hole1;;) {
         auto next = hole->op();
-        if (next != res) // avoid redundant update
-            hole->unset()->set(res);
+        if (next == res) break;
+
+        hole->unset()->set(res);
         hole = next->isa_mut<Hole>();
     }
 

--- a/src/mim/check.cpp
+++ b/src/mim/check.cpp
@@ -156,8 +156,8 @@ template<Checker::Mode mode> bool Checker::alpha_(const Def* d1_, const Def* d2_
             auto defs = DefVec(mut->ops().begin(), mut->ops().end());
             mut->unset();
             for (size_t i = 0, e = mut->num_ops(); i != e; ++i) mut->set(i, defs[i]->zonk());
+            // mut->type() will be automatically zonked after last op has been set
         }
-        // TODO set type
 
         size_t other = (i + 1) % 2;
         if (auto imm = mut->immutabilize())

--- a/src/mim/check.cpp
+++ b/src/mim/check.cpp
@@ -117,19 +117,10 @@ template<Checker::Mode mode> bool Checker::alpha_(const Def* d1_, const Def* d2_
     if ((!h1 && !d1->is_set()) || (!h2 && !d2->is_set())) return fail<mode>();
 
     if (mode == Check) {
-        if (h1 && h2) {
-            // union by rank
-            if (h1->rank() < h2->rank()) std::swap(h1, h2); // make sure h1 is heavier or equal
-            h2->set(h1);                                    // make h1 new root
-            if (h1->rank() == h2->rank()) ++h1->rank();
-            return true;
-        } else if (h1) {
-            h1->set(d2);
-            return true;
-        } else if (h2) {
-            h2->set(d1);
-            return true;
-        }
+        if (h1)
+            return h1->set(d2), true;
+        else if (h2)
+            return h2->set(d1), true;
     }
 
     auto muts          = std::array<Def*, 2>{d1->isa_mut(), d2->isa_mut()};

--- a/src/mim/check.cpp
+++ b/src/mim/check.cpp
@@ -50,7 +50,7 @@ const Def* Hole::find(const Def* def) {
     // path compression: set all Holes along the chain to res
     for (auto hole = def->isa_mut<Hole>(); hole && hole->op(); hole = def->isa_mut<Hole>()) {
         def = hole->op();
-        hole->reset(res);
+        hole->unset()->set(res);
     }
 
     return res;

--- a/src/mim/def.cpp
+++ b/src/mim/def.cpp
@@ -232,10 +232,11 @@ const Def* Def::refine(size_t i, const Def* new_op) const {
  * Def - set
  */
 
-// clang-format off
-Def* Def::  set(Defs ops) { assert(ops.size() == num_ops()); for (size_t i = 0, e = num_ops(); i != e; ++i)   set(i, ops[i]); return this; }
-Def* Def::reset(Defs ops) { assert(ops.size() == num_ops()); for (size_t i = 0, e = num_ops(); i != e; ++i) reset(i, ops[i]); return this; }
-// clang-format on
+Def* Def::set(Defs ops) {
+    assert(ops.size() == num_ops());
+    for (size_t i = 0, e = num_ops(); i != e; ++i) set(i, ops[i]);
+    return this;
+}
 
 Def* Def::set(size_t i, const Def* def) {
     invalidate();

--- a/src/mim/def.cpp
+++ b/src/mim/def.cpp
@@ -240,10 +240,7 @@ Def* Def::set(Defs ops) {
 
 Def* Def::set(size_t i, const Def* def) {
     def = check(i, def);
-    assert(def && !op(i) && curr_op_ == i);
-#ifndef NDEBUG
-    ++curr_op_;
-#endif
+    assert(def && !op(i) && curr_op_++ == i);
     ops_ptr()[i] = def;
 
     if (i + 1 == num_ops()) { // set last op, so check kind

--- a/src/mim/def.cpp
+++ b/src/mim/def.cpp
@@ -244,7 +244,7 @@ Def* Def::set(size_t i, const Def* def) {
     ops_ptr()[i] = def;
 
     if (i + 1 == num_ops()) { // set last op, so check kind
-        if (auto t = check(); t != type()) type_ = t;
+        if (auto t = check()->zonk(); t != type()) type_ = t;
     }
 
     return this;

--- a/src/mim/def.cpp
+++ b/src/mim/def.cpp
@@ -239,15 +239,14 @@ Def* Def::set(Defs ops) {
 }
 
 Def* Def::set(size_t i, const Def* def) {
-    invalidate();
     def = check(i, def);
     assert(def && !op(i) && curr_op_ == i);
 #ifndef NDEBUG
-    curr_op_ = (curr_op_ + 1) % num_ops();
+    ++curr_op_;
 #endif
     ops_ptr()[i] = def;
 
-    if (i == num_ops() - 1) { // set last op, so check kind
+    if (i + 1 == num_ops()) { // set last op, so check kind
         if (auto t = check(); t != type()) type_ = t;
     }
 
@@ -259,20 +258,7 @@ Def* Def::unset() {
 #ifndef NDEBUG
     curr_op_ = 0;
 #endif
-    for (size_t i = 0, e = num_ops(); i != e; ++i) {
-        if (op(i))
-            unset(i);
-        else {
-            assert(std::all_of(ops_ptr() + i + 1, ops_ptr() + num_ops(), [](auto op) { return !op; }));
-            break;
-        }
-    }
-    return this;
-}
-
-Def* Def::unset(size_t i) {
-    invalidate();
-    ops_ptr()[i] = nullptr;
+    std::ranges::fill(ops_ptr(), ops_ptr() + num_ops(), nullptr);
     return this;
 }
 

--- a/src/mim/normalize.cpp
+++ b/src/mim/normalize.cpp
@@ -1,5 +1,7 @@
 #include "mim/normalize.h"
 
+#include <fe/assert.h>
+
 #include "mim/world.h"
 
 namespace mim {
@@ -32,7 +34,8 @@ namespace mim {
 
     for (size_t i = 0, e = a->num_ops(); i != e; ++i)
         if (int cmp = commute_(a->op(i), b->op(i)); cmp != 0) return cmp;
-    assert(false);
+
+    fe::unreachable();
 }
 
 } // namespace mim

--- a/src/mim/normalize.cpp
+++ b/src/mim/normalize.cpp
@@ -15,7 +15,7 @@ namespace mim {
 
     if (a->isa_mut() && b->isa_mut()) {
         world.WLOG("resorting to unstable gid-based compare for commute check");
-        return a->gid() < a->gid() ? -1 : +1;
+        return a->gid() < b->gid() ? -1 : +1;
     }
 
     assert(a->isa_imm() && b->isa_imm());

--- a/src/mim/pass/pass.cpp
+++ b/src/mim/pass/pass.cpp
@@ -1,9 +1,9 @@
 #include "mim/pass/pass.h"
 
+#include <absl/container/fixed_array.h>
+
 #include "mim/phase/phase.h"
 #include "mim/util/util.h"
-
-#include "absl/container/fixed_array.h"
 
 namespace mim {
 

--- a/src/mim/pass/ret_wrap.cpp
+++ b/src/mim/pass/ret_wrap.cpp
@@ -15,7 +15,8 @@ void RetWrap::enter() {
     assert(new_vars.back() == ret_var && "we assume that the last element is the ret_var");
     new_vars.back() = ret_cont;
     auto new_var    = world().tuple(curr_mut()->dom(), new_vars);
-    curr_mut()->reset(curr_mut()->reduce(new_var));
+    auto new_defs   = curr_mut()->reduce(new_var);
+    curr_mut()->unset()->set(new_defs);
 }
 
 } // namespace mim

--- a/src/mim/plug/clos/pass/clos2sjlj.cpp
+++ b/src/mim/plug/clos/pass/clos2sjlj.cpp
@@ -128,7 +128,8 @@ void Clos2SJLJ::enter() {
         auto [m2, rb] = mem::op_slot(void_ptr(), m1)->projs<2>();
         auto new_args = curr_mut()->vars();
         new_args[0]   = m2;
-        curr_mut()->reset(curr_mut()->reduce(w.tuple(new_args)));
+        auto new_defs = curr_mut()->reduce(w.tuple(new_args));
+        curr_mut()->unset()->set(new_defs);
 
         cur_jbuf_ = jb;
         cur_rbuf_ = rb;
@@ -161,7 +162,7 @@ void Clos2SJLJ::enter() {
     tag            = w.call(core::conv::s, branches.size(), tag);
     auto filter    = curr_mut()->filter();
     auto branch    = w.extract(w.tuple(branches), tag);
-    curr_mut()->reset({filter, clos_apply(branch, m1)});
+    curr_mut()->unset()->set({filter, clos_apply(branch, m1)});
 }
 
 const Def* Clos2SJLJ::rewrite(const Def* def) {

--- a/src/mim/plug/clos/phase/clos_conv.cpp
+++ b/src/mim/plug/clos/phase/clos_conv.cpp
@@ -160,7 +160,7 @@ void ClosConv::rewrite_body(Lam* new_lam, Def2Def& subst) {
 
     auto filter = rewrite(new_fn->filter(), subst);
     auto body   = rewrite(new_fn->body(), subst);
-    new_fn->reset({filter, body});
+    new_fn->unset()->set({filter, body});
 }
 
 const Def* ClosConv::rewrite(const Def* def, Def2Def& subst) {

--- a/src/mim/plug/clos/phase/lower_typed_clos.cpp
+++ b/src/mim/plug/clos/phase/lower_typed_clos.cpp
@@ -28,7 +28,7 @@ void LowerTypedClos::start() {
         if (lam->is_set()) {
             auto new_f = rewrite(lam->filter());
             auto new_b = rewrite(lam->body());
-            lam->reset({new_f, new_b});
+            lam->unset()->set({new_f, new_b});
         }
     }
 

--- a/src/mim/plug/direct/pass/cps2ds.cpp
+++ b/src/mim/plug/direct/pass/cps2ds.cpp
@@ -98,7 +98,7 @@ const Def* CPS2DS::rewrite_body_(const Def* def) {
             world().DLOG("  curr_lam {}", curr_lam_->sym());
             if (curr_lam_->is_set()) {
                 auto filter = curr_lam_->filter();
-                curr_lam_->reset({filter, cps_call});
+                curr_lam_->unset()->set({filter, cps_call});
             } else {
                 curr_lam_->set(world().lit_ff(), cps_call);
             }

--- a/src/mim/rewrite.cpp
+++ b/src/mim/rewrite.cpp
@@ -2,6 +2,7 @@
 
 #include <absl/container/fixed_array.h>
 
+#include "mim/check.h"
 #include "mim/world.h"
 
 // Don't use fancy C++-lambdas; it's way too annoying stepping through them in a debugger.
@@ -9,6 +10,7 @@
 namespace mim {
 
 const Def* Rewriter::rewrite(const Def* old_def) {
+    old_def = Hole::find(old_def);
     if (old_def->isa<Univ>()) return world().univ();
     if (auto i = old2new_.find(old_def); i != old2new_.end()) return i->second;
     if (auto old_mut = old_def->isa_mut()) return rewrite_mut(old_mut);

--- a/src/mim/world.cpp
+++ b/src/mim/world.cpp
@@ -182,8 +182,7 @@ template<bool Normalize> const Def* World::app(const Def* callee, const Def* arg
     callee = callee->zonk();
     arg    = arg->zonk();
     if (auto pi = callee->type()->isa<Pi>()) {
-        auto dom = pi->dom()->zonk(); // TODO this is more a hotfix; callee->zonk() above should deal with this
-        if (auto new_arg = Checker::assignable(dom, arg)) {
+        if (auto new_arg = Checker::assignable(pi->dom(), arg)) {
             arg = new_arg->zonk();
             if (auto imm = callee->isa_imm<Lam>()) return imm->body();
 

--- a/src/mim/world.cpp
+++ b/src/mim/world.cpp
@@ -353,7 +353,7 @@ const Def* World::extract(const Def* d, const Def* index) {
     }
 
     if (auto i = Lit::isa(index)) {
-        if (auto hole = d->isa_mut<Hole>()) d = hole->tuplefy();
+        if (auto hole = d->isa_mut<Hole>()) d = hole->tuplefy(Idx::as_lit(index->type()));
         if (auto tuple = d->isa<Tuple>()) return tuple->op(*i);
 
         // extract(insert(x, j, val), i) -> extract(x, i) where i != j (guaranteed by rule above)


### PR DESCRIPTION
Various improvements/bugfixes concerning type inference.
In addition:
* removed Def::reset
* simplified Def::set
* Hole: removed union-by-rank (path compression is good enough and union-by-rank may swap operands which is highly confusing)
* docs