### PR TITLE
Cleanup

### DIFF
--- a/include/mim/ast/ast.h
+++ b/include/mim/ast/ast.h
@@ -740,13 +740,15 @@ private:
 };
 
 /// `«dbg: shape; body»` or `‹dbg: shape; body›`
-template<bool arr> class ArrOrPackExpr : public Expr {
+class SeqExpr : public Expr {
 public:
-    ArrOrPackExpr(Loc loc, Ptr<IdPtrn>&& shape, Ptr<Expr>&& body)
+    SeqExpr(Loc loc, bool is_arr, Ptr<IdPtrn>&& shape, Ptr<Expr>&& body)
         : Expr(loc)
+        , is_arr_(is_arr)
         , shape_(std::move(shape))
         , body_(std::move(body)) {}
 
+    bool is_arr() const { return is_arr_; }
     const IdPtrn* shape() const { return shape_.get(); }
     const Expr* body() const { return body_.get(); }
 
@@ -756,12 +758,10 @@ public:
 private:
     const Def* emit_(Emitter&) const override;
 
+    bool is_arr_;
     Ptr<IdPtrn> shape_;
     Ptr<Expr> body_;
 };
-
-using ArrExpr  = ArrOrPackExpr<true>;
-using PackExpr = ArrOrPackExpr<false>;
 
 /// `tuple#index`
 class ExtractExpr : public Expr {

--- a/include/mim/ast/parser.h
+++ b/include/mim/ast/parser.h
@@ -81,7 +81,6 @@ private:
 
     /// @name parse primary exprs
     ///@{
-    template<bool> Ptr<Expr> parse_arr_or_pack_expr();
     Ptr<Expr> parse_decl_expr();
     Ptr<Expr> parse_lit_expr();
     Ptr<Expr> parse_extremum_expr();
@@ -90,6 +89,7 @@ private:
     Ptr<Expr> parse_pi_expr();
     Ptr<Expr> parse_pi_expr(Ptr<Ptrn>&&);
     Ptr<Expr> parse_lam_expr();
+    Ptr<Expr> parse_seq_expr();
     Ptr<Expr> parse_sigma_expr();
     Ptr<Expr> parse_tuple_expr();
     Ptr<Expr> parse_insert_expr();

--- a/include/mim/axm.h
+++ b/include/mim/axm.h
@@ -131,7 +131,7 @@ public:
     static constexpr auto Node   = mim::Node::Axm;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };

--- a/include/mim/check.h
+++ b/include/mim/check.h
@@ -41,8 +41,8 @@ public:
     static constexpr auto Node = mim::Node::Hole;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
-    Hole* stub_(World&, const Def*) override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
+    Hole* stub_(World&, const Def*) final;
 
     friend class World;
     friend class Checker;

--- a/include/mim/check.h
+++ b/include/mim/check.h
@@ -36,7 +36,6 @@ public:
     const Def* tuplefy(nat_t);
 
     static const Def* isa(const Def*);
-    static DefVec zonk(Defs);
 
     static constexpr auto Node = mim::Node::Hole;
 

--- a/include/mim/check.h
+++ b/include/mim/check.h
@@ -18,6 +18,10 @@ public:
     /// @name op
     ///@{
     const Def* op() const { return Def::op(0); }
+
+    /// Transitively walks up Hole%s until the last one while path-compressing everything.
+    /// @returns the final Hole in the chain and final op() (if any).
+    std::pair<Hole*, const Def*> find();
     Hole* set(const Def* op) {
         assert(op != this);
         return Def::set(0, op)->as<Hole>();
@@ -31,8 +35,7 @@ public:
     /// @returns the new Tuple, or `this` if unsuccessful.
     const Def* tuplefy(nat_t);
 
-    /// [Union-Find](https://en.wikipedia.org/wiki/Disjoint-set_data_structure) to unify Hole%s.
-    static const Def* find(const Def*);
+    static const Def* isa(const Def*);
     static DefVec zonk(Defs);
 
     static constexpr auto Node = mim::Node::Hole;

--- a/include/mim/def.h
+++ b/include/mim/def.h
@@ -418,7 +418,6 @@ public:
     // clang-format off
     template<class T = Def> const T* isa_imm() const { return isa_mut<T, true>(); }
     template<class T = Def> const T*  as_imm() const { return  as_mut<T, true>(); }
-    template<class T = Def, class R> const T* isa_imm(R (T::*f)() const) const { return isa_mut<T, R, true>(f); }
     // clang-format on
 
     /// If `this` is *mutable*, it will cast `const`ness away and perform a `dynamic_cast` to @p T.

--- a/include/mim/def.h
+++ b/include/mim/def.h
@@ -528,7 +528,12 @@ public:
     /// Only gues up to but excluding other mutables.
     /// @see https://stackoverflow.com/questions/31889048/what-does-the-ghc-source-mean-by-zonk
     const Def* zonk() const;
+
+    /// zonk%s all ops of this *mutable* and tries to immutabilize it; if it succeeds return it.
+    const Def* zonk_mut();
     ///@}
+
+    static DefVec zonk(Defs);
 
     /// @name dump
     ///@{

--- a/include/mim/def.h
+++ b/include/mim/def.h
@@ -140,7 +140,12 @@ namespace mim {
     auto NAME##s(nat_t a) CONST noexcept { return ((const Def*)NAME())->projs(a); }
 
 /// CRTP-based Mixin to declare setters for Def::loc \& Def::name using a *covariant* return type.
-template<class P, class D = Def> class Setters { // D is only needed to make the resolution `D::template set` lazy
+template<class P, class D = Def>
+class // D is only needed to make the resolution `D::template set` lazy
+#ifdef _MSC_VER
+    __declspec(empty_bases)
+#endif
+        Setters {
 private:
     P* super() { return static_cast<P*>(this); }
     const P* super() const { return static_cast<const P*>(this); }

--- a/include/mim/def.h
+++ b/include/mim/def.h
@@ -623,7 +623,7 @@ public:
     static constexpr auto Node = mim::Node::Var;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };
@@ -637,7 +637,7 @@ private:
     Univ(World& world)
         : Def(&world, Node, nullptr, Defs{}, 0) {}
 
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };
@@ -650,7 +650,7 @@ public:
 private:
     UMax(World&, Defs ops);
 
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };
@@ -672,7 +672,7 @@ public:
     static constexpr auto Node = mim::Node::UInc;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };
@@ -693,7 +693,7 @@ public:
     static constexpr auto Node = mim::Node::Type;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };
@@ -731,7 +731,7 @@ public:
     static constexpr auto Node = mim::Node::Lit;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };
@@ -744,7 +744,7 @@ public:
 private:
     Nat(World& world);
 
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };
@@ -790,7 +790,7 @@ public:
     static constexpr auto Node = mim::Node::Idx;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };
@@ -812,7 +812,7 @@ public:
     static constexpr auto Node = mim::Node::Proxy;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };
@@ -853,8 +853,8 @@ public:
     static constexpr auto Node = mim::Node::Global;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
-    Global* stub_(World&, const Def*) override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
+    Global* stub_(World&, const Def*) final;
 
     friend class World;
 };

--- a/include/mim/def.h
+++ b/include/mim/def.h
@@ -291,7 +291,7 @@ public:
 
     /// Update type.
     /// @warning Only make type-preserving updates such as removing Hole%s.
-    /// @warning Do this even before updating all other ops!.
+    /// Do this even before updating all other ops()!.
     Def* set_type(const Def*);
     ///@}
 

--- a/include/mim/def.h
+++ b/include/mim/def.h
@@ -288,6 +288,11 @@ public:
     Def* set(Defs ops);             ///< Def::set @p ops all at once.
     Def* unset();                   ///< Unsets all Def::ops; works even, if not set at all or partially.
     bool is_set() const;            ///< Yields `true` if empty or the last op is set.
+
+    /// Update type.
+    /// @warning Only make type-preserving updates such as removing Hole%s.
+    /// @warning Do this even before updating all other ops!.
+    Def* set_type(const Def*);
     ///@}
 
     /// @name deps

--- a/include/mim/lam.h
+++ b/include/mim/lam.h
@@ -79,24 +79,24 @@ public:
 
     /// @name Type Checking
     ///@{
-    const Def* check(size_t, const Def*) override;
-    const Def* check() override;
+    const Def* check(size_t, const Def*) final;
+    const Def* check() final;
     static const Def* infer(const Def* dom, const Def* codom);
     ///@}
 
     /// @name Rebuild
     ///@{
     Pi* stub(const Def* type) { return stub_(world(), type)->set(dbg()); }
-    const Pi* immutabilize() override;
+    const Pi* immutabilize() final;
     const Def* reduce(const Def* arg) const { return Def::reduce(arg).front(); }
-    constexpr size_t reduction_offset() const noexcept override { return 1; }
+    constexpr size_t reduction_offset() const noexcept final { return 1; }
     ///@}
 
     static constexpr auto Node = mim::Node::Pi;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
-    Pi* stub_(World&, const Def*) override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
+    Pi* stub_(World&, const Def*) final;
 
     friend class World;
 };
@@ -179,19 +179,19 @@ public:
     ///@{
     Lam* stub(const Def* type) { return stub_(world(), type)->set(dbg()); }
     const Def* reduce_body(const Def* arg) const { return reduce(arg).back(); }
-    constexpr size_t reduction_offset() const noexcept override { return 0; }
+    constexpr size_t reduction_offset() const noexcept final { return 0; }
     ///@}
 
     /// @name Type Checking
     ///@{
-    const Def* check(size_t, const Def*) override;
+    const Def* check(size_t, const Def*) final;
     ///@}
 
     static constexpr auto Node = mim::Node::Lam;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
-    Lam* stub_(World&, const Def*) override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
+    Lam* stub_(World&, const Def*) final;
 
     friend class World;
 };
@@ -241,7 +241,7 @@ public:
     static constexpr auto Node = mim::Node::App;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };

--- a/include/mim/lattice.h
+++ b/include/mim/lattice.h
@@ -13,7 +13,7 @@ protected:
     Bound(Node node, const Def* type, Defs ops)
         : Def(node, type, ops, 0) {}
 
-    constexpr size_t reduction_offset() const noexcept override { return 0; }
+    constexpr size_t reduction_offset() const noexcept final { return 0; }
 
 public:
     /// @name Get Element by Type
@@ -39,7 +39,7 @@ public:
     static constexpr auto Node = Up ? mim::Node::Join : mim::Node::Meet;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };
@@ -55,7 +55,7 @@ private:
     Merge(const Def* type, Defs defs)
         : Def(Node, type, defs, 0) {}
 
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };
@@ -78,7 +78,7 @@ public:
     static constexpr auto Node = mim::Node::Inj;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };
@@ -100,7 +100,7 @@ public:
     static constexpr auto Node = mim::Node::Split;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };
@@ -124,7 +124,7 @@ public:
     ///@}
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };
@@ -148,7 +148,7 @@ public:
     static constexpr auto Node = Up ? mim::Node::Top : mim::Node::Bot;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };
@@ -180,7 +180,7 @@ public:
     static constexpr auto Node = mim::Node::Uniq;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };

--- a/include/mim/rewrite.h
+++ b/include/mim/rewrite.h
@@ -62,13 +62,13 @@ public:
         map(var, arg);
     }
 
-    const Def* rewrite_imm(const Def* imm) override {
+    const Def* rewrite_imm(const Def* imm) final {
         if (imm->local_vars().empty() && imm->local_muts().empty()) return imm; // safe to skip
         if (imm->has_dep(Dep::Hole) || vars_.has_intersection(imm->free_vars())) return Rewriter::rewrite_imm(imm);
         return imm;
     }
 
-    const Def* rewrite_mut(Def* mut) override {
+    const Def* rewrite_mut(Def* mut) final {
         if (vars_.has_intersection(mut->free_vars())) {
             if (auto var = mut->has_var()) vars_ = world().vars().insert(vars_, var);
             return Rewriter::rewrite_mut(mut);

--- a/include/mim/rewrite.h
+++ b/include/mim/rewrite.h
@@ -24,38 +24,13 @@ public:
     virtual const Def* rewrite_imm(const Def*);
     virtual const Def* rewrite_mut(Def*);
 
-    virtual const Def* rewrite_arr(const Arr* arr) { return rewrite_arr_or_pack<true>(arr); }
-    virtual const Def* rewrite_pack(const Pack* pack) { return rewrite_arr_or_pack<false>(pack); }
+    virtual const Def* rewrite_arr(const Arr*);
+    virtual const Def* rewrite_pack(const Pack*);
     virtual const Def* rewrite_extract(const Extract*);
+    virtual const Def* rewrite_hole(Hole*);
     ///@}
 
 private:
-    template<bool arr> const Def* rewrite_arr_or_pack(std::conditional_t<arr, const Arr*, const Pack*> pa) {
-        auto new_shape = rewrite(pa->shape());
-
-        if (auto l = Lit::isa(new_shape); l && *l <= world().flags().scalarize_threshold) {
-            auto new_ops = absl::FixedArray<const Def*>(*l);
-            for (size_t i = 0, e = *l; i != e; ++i) {
-                if (auto var = pa->has_var()) {
-                    auto old2new = old2new_;
-                    map(var, world().lit_idx(e, i));
-                    new_ops[i] = rewrite(pa->body());
-                    old2new_   = std::move(old2new);
-                } else {
-                    new_ops[i] = rewrite(pa->body());
-                }
-            }
-            return arr ? world().sigma(new_ops) : world().tuple(new_ops);
-        }
-
-        if (!pa->has_var()) {
-            auto new_body = rewrite(pa->body());
-            return arr ? world().arr(new_shape, new_body) : world().pack(new_shape, new_body);
-        }
-
-        return rewrite_mut(pa->as_mut());
-    }
-
     World& world_;
     Def2Def old2new_;
 };

--- a/include/mim/rewrite.h
+++ b/include/mim/rewrite.h
@@ -24,8 +24,9 @@ public:
     virtual const Def* rewrite_imm(const Def*);
     virtual const Def* rewrite_mut(Def*);
 
-    virtual const Def* rewrite_arr(const Arr*);
-    virtual const Def* rewrite_pack(const Pack*);
+    virtual const Def* rewrite_arr(const Arr* arr) { return rewrite_seq(arr); }
+    virtual const Def* rewrite_pack(const Pack* pack) { return rewrite_seq(pack); }
+    virtual const Def* rewrite_seq(const Seq*);
     virtual const Def* rewrite_extract(const Extract*);
     virtual const Def* rewrite_hole(Hole*);
     ///@}

--- a/include/mim/tuple.h
+++ b/include/mim/tuple.h
@@ -4,14 +4,20 @@
 
 namespace mim {
 
+/// Base class for Sigma and Tuple.
+class Prod : public Def, public Setters<Prod> {
+protected:
+    using Def::Def;
+};
+
 /// A [dependent tuple type](https://en.wikipedia.org/wiki/Dependent_type#%CE%A3_type).
-/// @see Tuple, Arr, Pack
-class Sigma : public Def, public Setters<Sigma> {
+/// @see Tuple, Arr, Pack, Prod
+class Sigma : public Prod, public Setters<Sigma> {
 private:
     Sigma(const Def* type, Defs ops)
-        : Def(Node, type, ops, 0) {} ///< Constructor for an *immutable* Sigma.
+        : Prod(Node, type, ops, 0) {} ///< Constructor for an *immutable* Sigma.
     Sigma(const Def* type, size_t size)
-        : Def(Node, type, size, 0) {} ///< Constructor for a *mutable* Sigma.
+        : Prod(Node, type, size, 0) {} ///< Constructor for a *mutable* Sigma.
 
 public:
     /// @name Setters
@@ -52,8 +58,8 @@ private:
 };
 
 /// Data constructor for a Sigma.
-/// @see Sigma, Arr, Pack
-class Tuple : public Def, public Setters<Tuple> {
+/// @see Sigma, Arr, Pack, Prod
+class Tuple : public Prod, public Setters<Tuple> {
 public:
     using Setters<Tuple>::set;
     static const Def* infer(World&, Defs);
@@ -61,7 +67,7 @@ public:
 
 private:
     Tuple(const Def* type, Defs args)
-        : Def(Node, type, args, 0) {}
+        : Prod(Node, type, args, 0) {}
 
     const Def* rebuild_(World&, const Def*, Defs) const override;
 

--- a/include/mim/tuple.h
+++ b/include/mim/tuple.h
@@ -107,7 +107,7 @@ private:
 public:
     /// @name ops
     ///@{
-    const Def* shape() const final { return op(0); }
+    const Def* shape() const override { return op(0); }
     ///@}
 
     /// @name Setters
@@ -127,7 +127,7 @@ public:
     const Def* immutabilize() override;
     const Def* reduce(const Def* arg) const { return Def::reduce(arg).front(); }
     constexpr size_t reduction_offset() const noexcept override { return 1; }
-    const Def* prod(World&, Defs) const final;
+    const Def* prod(World&, Defs) const override;
     ///@}
 
     /// @name Type Checking
@@ -157,7 +157,7 @@ private:
 public:
     /// @name ops
     ///@{
-    const Def* shape() const final;
+    const Def* shape() const override;
     ///@}
 
     /// @name Setters
@@ -176,7 +176,7 @@ public:
     const Def* immutabilize() override;
     const Def* reduce(const Def* arg) const { return Def::reduce(arg).front(); }
     constexpr size_t reduction_offset() const noexcept override { return 0; }
-    const Def* prod(World&, Defs) const final;
+    const Def* prod(World&, Defs) const override;
     ///@}
 
     static constexpr auto Node = mim::Node::Pack;

--- a/include/mim/tuple.h
+++ b/include/mim/tuple.h
@@ -31,28 +31,28 @@ public:
 
     /// @name Rebuild
     ///@{
-    const Def* immutabilize() override;
+    const Def* immutabilize() final;
     Sigma* stub(const Def* type) { return stub_(world(), type)->set(dbg()); }
 
     /// @note Technically, it would make sense to have an offset of 1 as the first element can't be reduced.
     /// For example, in `[n: Nat, F n]` `n` only occurs free in the second element.
     /// However, this would cause a lot of confusion and special code to cope with the first element,
     /// So we just keep it.
-    constexpr size_t reduction_offset() const noexcept override { return 0; }
+    constexpr size_t reduction_offset() const noexcept final { return 0; }
     ///@}
 
     /// @name Type Checking
     ///@{
-    const Def* check(size_t, const Def*) override;
-    const Def* check() override;
+    const Def* check(size_t, const Def*) final;
+    const Def* check() final;
     static const Def* infer(World&, Defs);
     ///@}
 
     static constexpr auto Node = mim::Node::Sigma;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
-    Sigma* stub_(World&, const Def*) override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
+    Sigma* stub_(World&, const Def*) final;
 
     friend class World;
 };
@@ -69,7 +69,7 @@ private:
     Tuple(const Def* type, Defs args)
         : Prod(Node, type, args, 0) {}
 
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };
@@ -107,7 +107,7 @@ private:
 public:
     /// @name ops
     ///@{
-    const Def* shape() const override { return op(0); }
+    const Def* shape() const final { return op(0); }
     ///@}
 
     /// @name Setters
@@ -122,25 +122,25 @@ public:
 
     /// @name Rebuild
     ///@{
-    const Def* rebuild(World& w, const Def* shape, const Def* body) const override;
+    const Def* rebuild(World& w, const Def* shape, const Def* body) const final;
     Arr* stub(const Def* type) { return stub_(world(), type)->set(dbg()); }
-    const Def* immutabilize() override;
+    const Def* immutabilize() final;
     const Def* reduce(const Def* arg) const { return Def::reduce(arg).front(); }
-    constexpr size_t reduction_offset() const noexcept override { return 1; }
-    const Def* prod(World&, Defs) const override;
+    constexpr size_t reduction_offset() const noexcept final { return 1; }
+    const Def* prod(World&, Defs) const final;
     ///@}
 
     /// @name Type Checking
     ///@{
-    const Def* check(size_t, const Def*) override;
-    const Def* check() override;
+    const Def* check(size_t, const Def*) final;
+    const Def* check() final;
     ///@}
 
     static constexpr auto Node = mim::Node::Arr;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
-    Arr* stub_(World&, const Def*) override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
+    Arr* stub_(World&, const Def*) final;
 
     friend class World;
 };
@@ -157,7 +157,7 @@ private:
 public:
     /// @name ops
     ///@{
-    const Def* shape() const override;
+    const Def* shape() const final;
     ///@}
 
     /// @name Setters
@@ -171,19 +171,19 @@ public:
 
     /// @name Rebuild
     ///@{
-    const Def* rebuild(World& w, const Def* shape, const Def* body) const override;
+    const Def* rebuild(World& w, const Def* shape, const Def* body) const final;
     Pack* stub(const Def* type) { return stub_(world(), type)->set(dbg()); }
-    const Def* immutabilize() override;
+    const Def* immutabilize() final;
     const Def* reduce(const Def* arg) const { return Def::reduce(arg).front(); }
-    constexpr size_t reduction_offset() const noexcept override { return 0; }
-    const Def* prod(World&, Defs) const override;
+    constexpr size_t reduction_offset() const noexcept final { return 0; }
+    const Def* prod(World&, Defs) const final;
     ///@}
 
     static constexpr auto Node = mim::Node::Pack;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
-    Pack* stub_(World&, const Def*) override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
+    Pack* stub_(World&, const Def*) final;
 
     friend class World;
 };
@@ -206,7 +206,7 @@ public:
     static constexpr auto Node = mim::Node::Extract;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };
@@ -233,7 +233,7 @@ public:
     static constexpr auto Node = mim::Node::Insert;
 
 private:
-    const Def* rebuild_(World&, const Def*, Defs) const override;
+    const Def* rebuild_(World&, const Def*, Defs) const final;
 
     friend class World;
 };

--- a/include/mim/world.h
+++ b/include/mim/world.h
@@ -395,6 +395,7 @@ public:
     /// Constructs a Lit of type Idx of size @p size.
     /// @note `size = 0` means `2^64`.
     const Lit* lit_idx(nat_t size, u64 val) { return lit(type_idx(size), val); }
+    const Lit* lit_idx_unsafe(u64 val) { return lit(type_idx(top(type_nat())), val); }
 
     template<class I> const Lit* lit_idx(I val) {
         static_assert(std::is_integral<I>());

--- a/lit/compile/ret_wrap.mim
+++ b/lit/compile/ret_wrap.mim
@@ -13,6 +13,6 @@ con extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (I8, 0), 0)
 lam extern _compile(): %compile.Pipeline =
     %compile.pipe
         (%compile.single_pass_phase %compile.internal_cleanup_pass)
-        (%compile.passes_to_phase 1 %compile.ret_wrap_pass);
+        (%compile.passes_to_phase %compile.ret_wrap_pass);
 
 // CHECK-DAG: con return

--- a/lit/compile/two_phase.mim
+++ b/lit/compile/two_phase.mim
@@ -13,7 +13,7 @@ con extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (I8, 0), 0)
 lam extern _compile(): %compile.Pipeline =
     %compile.pipe
         (%compile.single_pass_phase %compile.internal_cleanup_pass)
-        (%compile.passes_to_phase 1 %compile.ret_wrap_pass)
-        (%compile.passes_to_phase 1 %compile.ret_wrap_pass);
+        (%compile.passes_to_phase %compile.ret_wrap_pass)
+        (%compile.passes_to_phase %compile.ret_wrap_pass);
 
 // CHECK-DAG: con return

--- a/lit/regex/dont_compile.mim
+++ b/lit/regex/dont_compile.mim
@@ -7,4 +7,4 @@ import compile;
 lam extern _compile(): %compile.Pipeline =
     %compile.pipe
         (%compile.single_pass_phase %compile.internal_cleanup_pass)
-        (%compile.passes_to_phase 1 %compile.ret_wrap_pass);
+        (%compile.passes_to_phase %compile.ret_wrap_pass);

--- a/src/mim/ast/bind.cpp
+++ b/src/mim/ast/bind.cpp
@@ -11,7 +11,7 @@ public:
     DummyDecl()
         : Decl(Loc()) {}
 
-    std::ostream& stream(Tab&, std::ostream& os) const override { return os << "<dummy>"; }
+    std::ostream& stream(Tab&, std::ostream& os) const final { return os << "<dummy>"; }
 };
 
 class Scopes {

--- a/src/mim/ast/bind.cpp
+++ b/src/mim/ast/bind.cpp
@@ -206,15 +206,12 @@ void TupleExpr::bind(Scopes& s) const {
     for (const auto& elem : elems()) elem->bind(s);
 }
 
-template<bool arr> void ArrOrPackExpr<arr>::bind(Scopes& s) const {
+void SeqExpr::bind(Scopes& s) const {
     s.push();
     shape()->bind(s, false, false);
     body()->bind(s);
     s.pop();
 }
-
-template void ArrOrPackExpr<true>::bind(Scopes&) const;
-template void ArrOrPackExpr<false>::bind(Scopes&) const;
 
 void ExtractExpr::bind(Scopes& s) const {
     tuple()->bind(s);

--- a/src/mim/ast/emit.cpp
+++ b/src/mim/ast/emit.cpp
@@ -309,18 +309,18 @@ const Def* TupleExpr::emit_(Emitter& e) const {
     return e.world().tuple(elems);
 }
 
-template<bool arr> const Def* ArrOrPackExpr<arr>::emit_(Emitter& e) const {
+const Def* SeqExpr::emit_(Emitter& e) const {
     auto s = shape()->emit_type(e);
     if (shape()->dbg().is_anon()) { // immutable
         auto b = body()->emit(e);
-        return arr ? e.world().arr(s, b) : e.world().pack(s, b);
+        return is_arr() ? e.world().arr(s, b) : e.world().pack(s, b);
     }
 
     auto t = e.world().type_infer_univ();
     auto a = e.world().mut_arr(t);
     a->set_shape(s);
 
-    if (arr) {
+    if (is_arr()) {
         auto var = a->var();
         shape()->emit_value(e, var);
         a->set_body(body()->emit(e));
@@ -337,9 +337,6 @@ template<bool arr> const Def* ArrOrPackExpr<arr>::emit_(Emitter& e) const {
         return p;
     }
 }
-
-template const Def* ArrOrPackExpr<true>::emit_(Emitter&) const;
-template const Def* ArrOrPackExpr<false>::emit_(Emitter&) const;
 
 const Def* ExtractExpr::emit_(Emitter& e) const {
     auto tup = tuple()->emit(e);

--- a/src/mim/ast/stream.cpp
+++ b/src/mim/ast/stream.cpp
@@ -153,12 +153,9 @@ std::ostream& RetExpr::stream(Tab& tab, std::ostream& os) const {
 std::ostream& SigmaExpr::stream(Tab& tab, std::ostream& os) const { return ptrn()->stream(tab, os); }
 std::ostream& TupleExpr::stream(Tab& tab, std::ostream& os) const { return print(os, "({, })", R(tab, elems())); }
 
-template<bool arr> std::ostream& ArrOrPackExpr<arr>::stream(Tab& tab, std::ostream& os) const {
-    return print(os, "{}{}; {}{}", arr ? "«" : "‹", S(tab, shape()), S(tab, body()), arr ? "»" : "›");
+std::ostream& SeqExpr::stream(Tab& tab, std::ostream& os) const {
+    return print(os, "{}{}; {}{}", is_arr() ? "«" : "‹", S(tab, shape()), S(tab, body()), is_arr() ? "»" : "›");
 }
-
-template std::ostream& ArrOrPackExpr<true>::stream(Tab&, std::ostream&) const;
-template std::ostream& ArrOrPackExpr<false>::stream(Tab&, std::ostream&) const;
 
 std::ostream& ExtractExpr::stream(Tab& tab, std::ostream& os) const {
     if (auto expr = std::get_if<Ptr<Expr>>(&index())) return print(os, "{}#{}", S(tab, tuple()), S(tab, expr->get()));

--- a/src/mim/check.cpp
+++ b/src/mim/check.cpp
@@ -195,12 +195,12 @@ template<Checker::Mode mode> bool Checker::alpha_internal(const Def* d1, const D
         for (size_t i = 0; i != a; ++i)
             if (!alpha_<mode>(ts->op(i), d2->proj(a, i))) return fail<mode>();
         return true;
-    } else if (auto pa = d1->isa<Pack, Arr>()) {
-        if (pa->node() != d2->node()) return fail<mode>();
+    } else if (auto seq = d1->isa<Seq>()) {
+        if (seq->node() != d2->node()) return fail<mode>();
 
-        if (auto a = pa->isa_lit_arity()) {
+        if (auto a = seq->isa_lit_arity()) {
             for (size_t i = 0; i != *a; ++i)
-                if (!alpha_<mode>(pa->proj(*a, i), d2->proj(*a, i))) return fail<mode>();
+                if (!alpha_<mode>(seq->proj(*a, i), d2->proj(*a, i))) return fail<mode>();
             return true;
         }
 

--- a/src/mim/check.cpp
+++ b/src/mim/check.cpp
@@ -47,11 +47,12 @@ const Def* Def::zonk_mut() {
         }
 
     if (zonk) {
-        auto zonker  = Zonker(world());
-        auto old_ops = absl::FixedArray<const Def*>(ops().begin(), ops().end());
+        auto zonker   = Zonker(world());
+        auto old_type = type();
+        auto old_ops  = absl::FixedArray<const Def*>(ops().begin(), ops().end());
         unset();
+        set_type(zonker.rewrite(old_type));
         for (size_t i = 0, e = num_ops(); i != e; ++i) set(i, zonker.rewrite(old_ops[i]));
-        // mut->type() will be automatically zonked after last op has been set
     }
 
     if (auto imm = immutabilize()) return imm;

--- a/src/mim/check.cpp
+++ b/src/mim/check.cpp
@@ -190,10 +190,10 @@ template<Checker::Mode mode> bool Checker::alpha_internal(const Def* d1, const D
             return check1(arr, d1);
     }
 
-    if (auto ts = d1->isa<Tuple, Sigma>()) {
-        size_t a = ts->num_ops();
+    if (auto prod = d1->isa<Prod>()) {
+        size_t a = prod->num_ops();
         for (size_t i = 0; i != a; ++i)
-            if (!alpha_<mode>(ts->op(i), d2->proj(a, i))) return fail<mode>();
+            if (!alpha_<mode>(prod->op(i), d2->proj(a, i))) return fail<mode>();
         return true;
     } else if (auto seq = d1->isa<Seq>()) {
         if (seq->node() != d2->node()) return fail<mode>();

--- a/src/mim/def.cpp
+++ b/src/mim/def.cpp
@@ -250,6 +250,12 @@ Def* Def::set(size_t i, const Def* def) {
     return this;
 }
 
+Def* Def::set_type(const Def* type) {
+    assert(curr_op_ == 0);
+    type_ = type;
+    return this;
+}
+
 Def* Def::unset() {
     invalidate();
 #ifndef NDEBUG

--- a/src/mim/def.cpp
+++ b/src/mim/def.cpp
@@ -148,7 +148,7 @@ template<bool up> const Def* TBound<up>::rebuild_(World& w, const Def*  , Defs o
 
 Arr*    Arr   ::stub_(World& w, const Def* t) { return w.mut_arr  (t); }
 Global* Global::stub_(World& w, const Def* t) { return w.global   (t, is_mutable()); }
-Hole*   Hole  ::stub_(World& w, const Def* t) { return w.mut_hole(t); }
+Hole*   Hole  ::stub_(World& w, const Def* t) { return w.mut_hole (t); }
 Lam*    Lam   ::stub_(World& w, const Def* t) { return w.mut_lam  (t->as<Pi>()); }
 Pack*   Pack  ::stub_(World& w, const Def* t) { return w.mut_pack (t); }
 Pi*     Pi    ::stub_(World& w, const Def* t) { return w.mut_pi   (t, is_implicit()); }

--- a/src/mim/dump.cpp
+++ b/src/mim/dump.cpp
@@ -314,7 +314,7 @@ void Dumper::dump(Def* mut) {
         if (auto arr = def->isa<Arr>()) return print(os, ", {}", arr->shape());
         if (auto pack = def->isa<Pack>()) return print(os, ", {}", pack->shape());
         if (auto pi = def->isa<Pi>()) return print(os, ", {}", pi->dom());
-        if (auto hole = def->isa<Hole>()) return hole->is_set() ? print(os, ", {}", hole->op()) : print(os, ", ??");
+        if (auto hole = def->isa_mut<Hole>()) return hole->is_set() ? print(os, ", {}", hole->op()) : print(os, ", ??");
         fe::unreachable();
     };
 

--- a/src/mim/plug/autodiff/autodiff.mim
+++ b/src/mim/plug/autodiff/autodiff.mim
@@ -57,15 +57,15 @@ axm %autodiff.ad_ext_cleanup_pass:  %compile.Pass;
 /// ### Phases
 ///
 let ad_cleanup_phase =
-    %compile.phases_to_phase (⊤:Nat) (
-        (%compile.passes_to_phase 1 %autodiff.ad_zero_cleanup_pass),
-        (%compile.passes_to_phase 1 %autodiff.ad_ext_cleanup_pass)
+    %compile.phases_to_phase (
+        (%compile.passes_to_phase %autodiff.ad_zero_cleanup_pass),
+        (%compile.passes_to_phase %autodiff.ad_ext_cleanup_pass)
     );
 let ad_phase =
-    %compile.phases_to_phase (⊤:Nat) (
+    %compile.phases_to_phase (
         optimization_phase,
-        (%compile.passes_to_phase 1 %autodiff.ad_eval_pass),
-        (%compile.passes_to_phase 1 %autodiff.ad_zero_pass),
+        (%compile.passes_to_phase %autodiff.ad_eval_pass),
+        (%compile.passes_to_phase %autodiff.ad_zero_pass),
         ad_cleanup_phase
     );
 ///

--- a/src/mim/plug/compile/compile.mim
+++ b/src/mim/plug/compile/compile.mim
@@ -79,10 +79,10 @@ axm %compile.debug_phase: Nat → %compile.Phase;
 axm %compile.pass_list: %compile.PassList;
 /// `pass_phase (pass_list pass1 ... passN) = passes_to_phase N (pass1, ..., passN)`
 axm %compile.pass_phase: %compile.PassList → %compile.Phase, normalize_pass_phase;
-axm %compile.passes_to_phase: [n: Nat] → «n; %compile.Pass» → %compile.Phase;
+axm %compile.passes_to_phase: {n: Nat} → «n; %compile.Pass» → %compile.Phase;
 /// `combine_pass_list K (pass_list pass11 ... pass1N) ... (pass_list passK1 ... passKM) = pass_list pass11 ... p1N ... passK1 ... passKM`
-axm %compile.combine_pass_list: [n: Nat] → «n; %compile.PassList» → %compile.PassList, normalize_combine_pass_list;
-/// `single_pass_phase pass = passes_to_phase 1 pass`
+axm %compile.combine_pass_list: {n: Nat} → «n; %compile.PassList» → %compile.PassList, normalize_combine_pass_list;
+/// `single_pass_phase pass = passes_to_phase pass`
 // TODO: as let instead of axiom
 axm %compile.single_pass_phase: %compile.Pass → %compile.Phase, normalize_single_pass_phase;
 ///
@@ -93,7 +93,7 @@ axm %compile.single_pass_phase: %compile.Pass → %compile.Phase, normalize_sing
 axm %compile.phase_list: %compile.CombinedPhase;
 /// `combined_phase (phase_list phase1 ... phaseN) = phases_to_phase N (phase1, ..., phaseN)`
 axm %compile.combined_phase: %compile.CombinedPhase → %compile.Phase, normalize_combined_phase;
-axm %compile.phases_to_phase: [n: Nat] → «n; %compile.Phase» → %compile.Phase;
+axm %compile.phases_to_phase: {n: Nat} → «n; %compile.Phase» → %compile.Phase;
 ///
 /// ### Passes
 ///
@@ -147,9 +147,9 @@ lam extern _fallback_compile(): %compile.Pipeline = default_core_pipeline;
 /// ### Dependent Passes and Phases
 ///
 let empty_pass = %compile.nullptr_pass;
-let empty_phase = %compile.passes_to_phase 0 ();
+let empty_phase = %compile.passes_to_phase ();
 axm %compile.plugin_select: [T: *] → %compile.Plugin → T → T → T;
 let plugin_phase = %compile.plugin_select %compile.Phase;
 let plugin_pass = %compile.plugin_select %compile.Pass;
 lam plugin_cond_phase(plug: %compile.Plugin, phase: %compile.Phase): %compile.Phase = plugin_phase plug phase empty_phase;
-lam plugin_cond_pass(plug: %compile.Plugin, pass: %compile.Pass): %compile.Pass = plugin_pass plug pass empty_pass;
+lam plugin_cond_pass (plug: %compile.Plugin, pass:  %compile.Pass ): %compile.Pass  = plugin_pass  plug pass  empty_pass;

--- a/src/mim/plug/compile/normalizers.cpp
+++ b/src/mim/plug/compile/normalizers.cpp
@@ -20,9 +20,8 @@ const Def* normalize_pass_phase(const Def* type, const Def*, const Def* arg) {
 
     auto [f_ax, pass_list_defs] = collect_args(arg);
     assert(f_ax->flags() == flags_t(Annex::Base<pass_list>));
-    auto n = pass_list_defs.size();
 
-    return world.call<passes_to_phase>(n, pass_list_defs);
+    return world.call<passes_to_phase>(pass_list_defs);
 }
 
 /// `combined_phase (phase_list phase1 ... phasen)` -> `phases_to_phase n (phase1, ..., phasen)`
@@ -31,14 +30,13 @@ const Def* normalize_combined_phase(const Def* type, const Def*, const Def* arg)
 
     auto [ax, phase_list_defs] = collect_args(arg);
     assert(ax->flags() == flags_t(Annex::Base<phase_list>));
-    auto n = phase_list_defs.size();
 
-    return world.call<phases_to_phase>(n, phase_list_defs);
+    return world.call<phases_to_phase>(phase_list_defs);
 }
 
-/// `single_pass_phase pass` -> `passes_to_phase 1 pass`
+/// `single_pass_phase pass` -> `passes_to_phase pass`
 const Def* normalize_single_pass_phase(const Def* type, const Def*, const Def* arg) {
-    return type->world().call<passes_to_phase>(1, arg);
+    return type->world().call<passes_to_phase>(arg);
 }
 
 /// `combine_pass_list K (pass_list pass11 ... pass1N) ... (pass_list passK1 ... passKM) = pass_list pass11 ... p1N ...

--- a/src/mim/plug/core/core.mim
+++ b/src/mim/plug/core/core.mim
@@ -64,6 +64,10 @@ let %core.mode.nusw = %core.mode.US;
 ///
 axm %core.idx: [s: Nat] → [m: Nat] → [l: Nat] → Idx s, normalize_idx;
 ///
+/// Creates a literal of type `Idx ⊤`.
+///
+axm %core.idx_unsafe: Nat → Idx ⊤:Nat, normalize_idx_unsafe;
+///
 /// ### %%core.bit1
 ///
 /// This *unary* bitwise operations offers all [4 possible operations](https://en.wikipedia.org/wiki/Truth_table#Unary_operations) as summarized in the following table:

--- a/src/mim/plug/core/normalizers.cpp
+++ b/src/mim/plug/core/normalizers.cpp
@@ -422,6 +422,12 @@ const Def* normalize_idx(const Def* type, const Def* c, const Def* arg) {
     return {};
 }
 
+const Def* normalize_idx_unsafe(const Def* type, const Def* c, const Def* arg) {
+    auto& world = type->world();
+    if (auto i = Lit::isa(arg)) return world.lit_idx_unsafe(*i);
+    return {};
+}
+
 template<shr id> const Def* normalize_shr(const Def* type, const Def* c, const Def* arg) {
     auto& world = type->world();
     auto callee = c->as<App>();
@@ -491,7 +497,7 @@ template<wrap id> const Def* normalize_wrap(const Def* type, const Def* c, const
             }
         }
 
-        if (auto lm = Lit::isa(mode); lm && *lm == 0 && id == wrap::sub)
+        if (auto lm = Lit::isa(mode); lm && ls && *lm == 0 && id == wrap::sub)
             return world.call(wrap::add, mode, Defs{a, world.lit_idx_mod(*ls, ~*lb + 1_u64)}); // a - lb -> a + (~lb + 1)
         else if (id == wrap::shl && ls && *lb > *ls)
             return world.bot(type);

--- a/src/mim/plug/matrix/matrix.mim
+++ b/src/mim/plug/matrix/matrix.mim
@@ -238,7 +238,7 @@ axm %matrix.lower_matrix_low_level:             %compile.Phase;
 /// ### Phases
 ///
 let matrix_lower_phase =
-    %compile.phases_to_phase (⊤:Nat)
+    %compile.phases_to_phase
     (
         (%compile.pass_phase
             (%compile.pass_list

--- a/src/mim/plug/mem/mem.mim
+++ b/src/mim/plug/mem/mem.mim
@@ -128,4 +128,4 @@ let mem_opt_pass_list =
         (%mem.copy_prop_pass (beta_red, eta_exp, ff));
 
 let mem_opt_phase  = %compile.pass_phase mem_opt_pass_list;
-let mem_prep_phase = %compile.passes_to_phase (⊤:Nat) (%mem.remem_elim_pass, %mem.alloc2malloc_pass);
+let mem_prep_phase = %compile.passes_to_phase (%mem.remem_elim_pass, %mem.alloc2malloc_pass);

--- a/src/mim/plug/opt/opt.mim
+++ b/src/mim/plug/opt/opt.mim
@@ -33,7 +33,7 @@ lam extern _default_compile []: %compile.Pipeline =
         (%compile.single_pass_phase (plugin_cond_pass (%compile.regex_plugin, %regex.lower_regex)))
         // optimize
         (%compile.pass_phase
-            (%compile.combine_pass_list (⊤:Nat)
+            (%compile.combine_pass_list
             (
                 optimization_pass_list,
                 %compile.pass_list
@@ -62,7 +62,7 @@ lam extern _default_compile []: %compile.Pipeline =
         (plugin_cond_phase (%compile.autodiff_plugin, ad_cleanup_phase))
         // CodeGenPrep
         (%compile.pass_phase
-            (%compile.combine_pass_list (⊤:Nat)
+            (%compile.combine_pass_list
             (
                 %compile.pass_list
                 %compile.ret_wrap_pass,

--- a/src/mim/plug/tuple/normalizers.cpp
+++ b/src/mim/plug/tuple/normalizers.cpp
@@ -65,7 +65,7 @@ const Def* normalize_zip(const Def* type, const Def* c, const Def* arg) {
     if (auto l_in = Lit::isa(n_i)) {
         auto args = arg->projs(*l_in);
 
-        if (lr && std::ranges::all_of(args, [](const Def* arg) { return arg->isa<Tuple, Pack>(); })) {
+        if (lr && std::ranges::all_of(args, [](const Def* arg) { return arg->isa<Prod>(); })) {
             auto shapes = s->projs(*lr);
             auto s_n    = Lit::isa(shapes.front());
 

--- a/src/mim/rewrite.cpp
+++ b/src/mim/rewrite.cpp
@@ -10,14 +10,14 @@
 namespace mim {
 
 const Def* Rewriter::rewrite(const Def* old_def) {
-    old_def = Hole::find(old_def);
     if (old_def->isa<Univ>()) return world().univ();
     if (auto i = old2new_.find(old_def); i != old2new_.end()) return i->second;
 
     // clang-format off
-    if (auto arr     = old_def->isa<Arr    >()) return rewrite_arr    (arr   ) ;
-    if (auto pack    = old_def->isa<Pack   >()) return rewrite_pack   (pack   );
-    if (auto extract = old_def->isa<Extract>()) return rewrite_extract(extract);
+    if (auto arr     = old_def->isa<Arr     >()) return rewrite_arr    (arr    );
+    if (auto pack    = old_def->isa<Pack    >()) return rewrite_pack   (pack   );
+    if (auto extract = old_def->isa<Extract >()) return rewrite_extract(extract);
+    if (auto hole    = old_def->isa_mut<Hole>()) return rewrite_hole   (hole   );
     // clang-format on
 
     if (auto old_mut = old_def->isa_mut()) return rewrite_mut(old_mut);
@@ -45,16 +45,75 @@ const Def* Rewriter::rewrite_mut(Def* old_mut) {
     return new_mut;
 }
 
-const Def* Rewriter::rewrite_extract(const Extract* extract) {
-    auto new_index = rewrite(extract->index());
-    if (auto index = Lit::isa(new_index)) {
-        if (auto tuple = extract->tuple()->isa<Tuple>()) return rewrite(tuple->op(*index));
-        if (auto pack = extract->tuple()->isa_imm<Pack>(); pack && pack->shape()->is_closed())
-            return rewrite(pack->body());
+const Def* Rewriter::rewrite_arr(const Arr* arr) {
+    if (!arr->is_set()) {
+        auto new_arr = world().mut_arr(rewrite(arr->type()))->set(arr->dbg());
+        return map(arr, new_arr);
     }
 
-    auto new_tuple = rewrite(extract->tuple());
-    return world().extract(new_tuple, new_index)->set(extract->dbg());
+    auto new_shape = rewrite(arr->shape());
+
+    if (auto l = Lit::isa(new_shape); l && *l <= world().flags().scalarize_threshold) {
+        auto new_ops = absl::FixedArray<const Def*>(*l);
+        for (size_t i = 0, e = *l; i != e; ++i) {
+            if (auto var = arr->has_var()) {
+                auto old2new = old2new_;
+                map(var, world().lit_idx(e, i));
+                new_ops[i] = rewrite(arr->body());
+                old2new_   = std::move(old2new);
+            } else {
+                new_ops[i] = rewrite(arr->body());
+            }
+        }
+        return map(arr, world().sigma(new_ops));
+    }
+
+    if (!arr->has_var()) return map(arr, world().arr(new_shape, rewrite(arr->body()))->set(arr->dbg()));
+    return rewrite_mut(arr->as_mut());
+}
+
+const Def* Rewriter::rewrite_pack(const Pack* pack) {
+    if (!pack->is_set()) {
+        auto new_pack = world().mut_arr(rewrite(pack->type()))->set(pack->dbg());
+        return map(pack, new_pack);
+    }
+
+    auto new_shape = rewrite(pack->shape());
+
+    if (auto l = Lit::isa(new_shape); l && *l <= world().flags().scalarize_threshold) {
+        auto new_ops = absl::FixedArray<const Def*>(*l);
+        for (size_t i = 0, e = *l; i != e; ++i) {
+            if (auto var = pack->has_var()) {
+                auto old2new = old2new_;
+                map(var, world().lit_idx(e, i));
+                new_ops[i] = rewrite(pack->body());
+                old2new_   = std::move(old2new);
+            } else {
+                new_ops[i] = rewrite(pack->body());
+            }
+        }
+        return world().tuple(new_ops);
+    }
+
+    if (!pack->has_var()) return map(pack, world().pack(new_shape, rewrite(pack->body()))->set(pack->dbg()));
+    return rewrite_mut(pack->as_mut());
+}
+
+const Def* Rewriter::rewrite_extract(const Extract* ex) {
+    auto new_index = rewrite(ex->index());
+    if (auto index = Lit::isa(new_index)) {
+        if (auto tuple = ex->tuple()->isa<Tuple>()) return map(ex, rewrite(tuple->op(*index)));
+        if (auto pack = ex->tuple()->isa_imm<Pack>(); pack && pack->shape()->is_closed())
+            return map(ex, rewrite(pack->body()));
+    }
+
+    auto new_tuple = rewrite(ex->tuple());
+    return map(ex, world().extract(new_tuple, new_index)->set(ex->dbg()));
+}
+
+const Def* Rewriter::rewrite_hole(Hole* hole) {
+    auto [last, op] = hole->find();
+    return op ? rewrite(op) : rewrite_mut(last);
 }
 
 } // namespace mim

--- a/src/mim/rewrite.cpp
+++ b/src/mim/rewrite.cpp
@@ -11,7 +11,7 @@ namespace mim {
 
 const Def* Rewriter::rewrite(const Def* old_def) {
     if (old_def->isa<Univ>()) return world().univ();
-    if (auto i = old2new_.find(old_def); i != old2new_.end()) return i->second;
+    if (auto new_def = lookup(old_def)) return new_def;
 
     // clang-format off
     if (auto arr     = old_def->isa<Arr     >()) return rewrite_arr    (arr    );
@@ -57,10 +57,10 @@ const Def* Rewriter::rewrite_seq(const Seq* seq) {
         auto new_ops = absl::FixedArray<const Def*>(*l);
         for (size_t i = 0, e = *l; i != e; ++i) {
             if (auto var = seq->has_var()) {
-                auto old2new = old2new_;
+                push();
                 map(var, world().lit_idx(e, i));
                 new_ops[i] = rewrite(seq->body());
-                old2new_   = std::move(old2new);
+                pop();
             } else {
                 new_ops[i] = rewrite(seq->body());
             }

--- a/src/mim/tuple.cpp
+++ b/src/mim/tuple.cpp
@@ -8,6 +8,14 @@
 
 namespace mim {
 
+// clang-format off
+const Def* Arr ::rebuild(World& w, const Def* shape, const Def* body) const { return w.arr (shape, body)->set(dbg()); }
+const Def* Pack::rebuild(World& w, const Def* shape, const Def* body) const { return w.pack(shape, body)->set(dbg()); }
+
+const Def* Arr ::prod(World& w, Defs ops) const { return w.sigma(ops)->set(dbg()); }
+const Def* Pack::prod(World& w, Defs ops) const { return w.tuple(ops)->set(dbg()); }
+// clang-format on
+
 namespace {
 bool should_flatten(const Def* def) {
     auto type = (def->is_term() ? def->type() : def);

--- a/src/mim/world.cpp
+++ b/src/mim/world.cpp
@@ -274,7 +274,7 @@ const Def* World::sigma(Defs ops) {
     if (n == 0) return sigma();
     if (n == 1) return ops[0]->zonk();
 
-    auto zops = Hole::zonk(ops);
+    auto zops = Def::zonk(ops);
     if (auto uni = Checker::is_uniform(zops)) return arr(n, uni);
     return unify<Sigma>(zops.size(), Sigma::infer(*this, zops), ops);
 }
@@ -284,7 +284,7 @@ const Def* World::tuple(Defs ops) {
     if (n == 0) return tuple();
     if (n == 1) return ops[0]->zonk();
 
-    auto zops  = Hole::zonk(ops);
+    auto zops  = Def::zonk(ops);
     auto sigma = Tuple::infer(*this, zops);
     auto t     = tuple(sigma, zops);
     auto new_t = Checker::assignable(sigma, t);
@@ -297,7 +297,7 @@ const Def* World::tuple(Defs ops) {
 const Def* World::tuple(const Def* type, Defs ops_) {
     // TODO type-check type vs inferred type
     type     = type->zonk();
-    auto ops = Hole::zonk(ops_);
+    auto ops = Def::zonk(ops_);
 
     auto n = ops.size();
     if (!type->isa_mut<Sigma>()) {
@@ -568,7 +568,7 @@ template<bool Up> const Def* World::bound(Defs ops_) {
 
 const Def* World::merge(const Def* type, Defs ops_) {
     type     = type->zonk();
-    auto ops = Hole::zonk(ops_);
+    auto ops = Def::zonk(ops_);
 
     if (type->isa<Meet>()) {
         auto types = DefVec(ops.size(), [&](size_t i) { return ops[i]->type(); });
@@ -580,7 +580,7 @@ const Def* World::merge(const Def* type, Defs ops_) {
 }
 
 const Def* World::merge(Defs ops_) {
-    auto ops = Hole::zonk(ops_);
+    auto ops = Def::zonk(ops_);
     return merge(umax<Sort::Term>(ops), ops);
 }
 
@@ -600,7 +600,7 @@ const Def* World::split(const Def* type, const Def* value) {
 }
 
 const Def* World::match(Defs ops_) {
-    auto ops = Hole::zonk(ops_);
+    auto ops = Def::zonk(ops_);
     if (ops.size() == 1) return ops.front();
 
     auto scrutinee = ops.front();

--- a/src/mim/world.cpp
+++ b/src/mim/world.cpp
@@ -520,7 +520,9 @@ const Lit* World::lit(const Def* type, u64 val) {
     type = type->zonk();
 
     if (auto size = Idx::isa(type)) {
-        if (auto s = Lit::isa(size)) {
+        if (size->isa<Top>()) {
+            // unsafe but fine
+        } else if (auto s = Lit::isa(size)) {
             if (*s != 0 && val >= *s) error(type->loc(), "index '{}' does not fit within arity '{}'", size, val);
         } else if (val != 0) { // 0 of any size is allowed
             error(type->loc(), "cannot create literal '{}' of 'Idx {}' as size is unknown", val, size);


### PR DESCRIPTION
* New common base for `Arr` and `Pack`: `Seq`
    * This allows for more straightforward code sharing
* Similrarly: `ArrOrPackExpr` -> `SeqExpr`
* Rewriter now uses a stack of `Def2Def` maps instead of copies
* Type inference for `%compile` axioms
* Use `final` in overloads for subclasses of `Def`.
* refactoring    
    


