### PR TITLE
Expand normalizer for nats

### DIFF
--- a/src/mim/plug/core/normalizers.cpp
+++ b/src/mim/plug/core/normalizers.cpp
@@ -244,8 +244,8 @@ template<nat id> const Def* normalize_nat(const Def* type, const Def* callee, co
 
     if (a == b) {
         switch (id) {
-            case nat::add: return world.call(nat::mul, Defs{world.lit_nat(2), a});
-            case nat::sub: return world.lit_nat(0);
+            case nat::add: return world.call(nat::mul, Defs{world.lit_nat(2), a}); // a + a = 2 * a
+            case nat::sub: return world.lit_nat(0);                                // a - a = 0
             case nat::mul: break;
         }
     }

--- a/src/mim/plug/core/normalizers.cpp
+++ b/src/mim/plug/core/normalizers.cpp
@@ -242,6 +242,14 @@ template<nat id> const Def* normalize_nat(const Def* type, const Def* callee, co
 
     if (lb && *lb == 0 && id == nat::sub) return a; // a - 0 = a
 
+    if (a == b) {
+        switch (id) {
+            case nat::add: return world.call(nat::mul, Defs{world.lit_nat(2), a});
+            case nat::sub: return world.lit_nat(0);
+            case nat::mul: break;
+        }
+    }
+
     return world.raw_app(type, callee, {a, b});
 }
 


### PR DESCRIPTION
As discussed ,adding the normalizations a+a = 2*a and a - a = 0
This makes the nat normalizer equivalent to the wrap one. 
If it is not needed, feel free to reject.