### PR TITLE
force libmem as shared library even with BUILD_SHARED_LIBS=OFF

### DIFF
--- a/src/mim/CMakeLists.txt
+++ b/src/mim/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(libmim)
+add_library(libmim SHARED)
 target_sources(libmim
     PRIVATE
         axm.cpp


### PR DESCRIPTION
For issue #320, reduce the dependencies of shared libraries so that we could have one cli + single libmem.so + plugins so with BUILD_SHARED_LIBS=OFF.